### PR TITLE
Refactor KV cache allocation logic for GPU memory

### DIFF
--- a/nanovllm_voxcpm/engine/model_runner.py
+++ b/nanovllm_voxcpm/engine/model_runner.py
@@ -216,9 +216,9 @@ class BaseModelRunner:
 
     def allocate_kv_cache(self):
         free, total = torch.cuda.mem_get_info()
-        used = total - free
         peak = torch.cuda.memory_stats()["allocated_bytes.all.peak"]
         current = torch.cuda.memory_stats()["allocated_bytes.all.current"]
+        reserved = torch.cuda.memory_reserved()
 
         total_attention_block_size = 0
         for module in self.model.modules():
@@ -227,9 +227,10 @@ class BaseModelRunner:
                     2 * self.block_size * module.num_kv_heads * module.head_dim * self.dtype.itemsize
                 )
 
-        self._config.num_kvcache_blocks = (
-            int(total * self._config.gpu_memory_utilization - used - peak + current) // total_attention_block_size
-        )
+        available_budget = total * self._config.gpu_memory_utilization - peak
+        available_physical = free + (reserved - current) - (peak - current)
+        available_for_kv = min(available_budget, available_physical)
+        self._config.num_kvcache_blocks = int(available_for_kv) // total_attention_block_size
         assert self._config.num_kvcache_blocks > 0
 
         for module in self.model.modules():


### PR DESCRIPTION
代码中 used = total - free 获取的是整张显卡所有进程的总占用显存。但如果该卡上存在其他进程，那么 used 就会变得很大。此时计算 total * 0.4 - used 会得出一个负数，从而导致 num_kvcache_blocks <= 0，最终触发 assert self._config.num_kvcache_blocks > 0 报错。

逻辑缺陷在于：它将 vLLM 实例自身的预留限额（total * 0.4）与全局已使用显存（used）直接相减。而在标准的 vLLM 设计中，gpu_memory_utilization 仅限制当前进程的上限，计算剩余空间时应当基于当前进程实际分配  (peak/current) 的显存。