### PR TITLE
test(scheduler): regression coverage for decode self-preempt empty batch

### DIFF
--- a/tests/unit/test_scheduler_empty_decode_batch.py
+++ b/tests/unit/test_scheduler_empty_decode_batch.py
@@ -1,0 +1,102 @@
+"""Regression test for the decode-phase self-preempt branch.
+
+When decode runs with a single running sequence and the block manager
+reports that it cannot append to that sequence, ``Scheduler.schedule``
+takes the ``else: self.preempt(seq); break`` branch. That legitimately
+leaves ``scheduled_seqs`` empty. Before the assert was removed from
+``Scheduler.schedule``, this crashed the inference process; the parent
+server then hung silently on its output queue.
+
+The assert has been removed on main and ``LLMEngineBase.step`` already
+short-circuits on an empty schedule, but the self-preempt decode branch
+did not have a dedicated regression test covering the specific path
+that triggered this in production.
+"""
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("xxhash")
+pytest.importorskip("torch")
+
+
+def test_decode_self_preempt_returns_empty_without_crash(tmp_path, monkeypatch):
+    from nanovllm_voxcpm.config import Config
+    from nanovllm_voxcpm.engine.scheduler import Scheduler
+    from nanovllm_voxcpm.engine.sequence import Sequence, SequenceStatus
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    cfg = Config(
+        model=str(model_dir),
+        max_num_batched_tokens=4096,
+        max_num_seqs=1,
+        max_model_len=512,
+        kvcache_block_size=256,
+        num_kvcache_blocks=4,
+        tensor_parallel_size=1,
+    )
+    sched = Scheduler(cfg)
+
+    only = Sequence("only", list(range(128)), cfg.kvcache_block_size)
+    sched.add(only)
+
+    first_seqs, first_is_prefill = sched.schedule()
+    assert first_is_prefill is True
+    assert first_seqs == [only]
+    assert only.status == SequenceStatus.RUNNING
+
+    monkeypatch.setattr(sched.block_manager, "can_append", lambda seq: False)
+
+    seqs, is_prefill = sched.schedule()
+
+    assert seqs == []
+    assert is_prefill is False
+    assert only.status == SequenceStatus.WAITING
+    assert list(s.seq_id for s in sched.waiting) == ["only"]
+    assert not sched.running
+
+
+def test_engine_step_is_noop_when_decode_self_preempts(tmp_path, monkeypatch):
+    from nanovllm_voxcpm.config import Config
+    from nanovllm_voxcpm.engine.llm_engine import LLMEngineBase
+    from nanovllm_voxcpm.engine.scheduler import Scheduler
+    from nanovllm_voxcpm.engine.sequence import Sequence
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    cfg = Config(
+        model=str(model_dir),
+        max_num_batched_tokens=4096,
+        max_num_seqs=1,
+        max_model_len=512,
+        kvcache_block_size=256,
+        num_kvcache_blocks=4,
+        tensor_parallel_size=1,
+    )
+    sched = Scheduler(cfg)
+    sched.add(Sequence("only", list(range(128)), cfg.kvcache_block_size))
+    sched.schedule()
+
+    monkeypatch.setattr(sched.block_manager, "can_append", lambda seq: False)
+
+    class _Runner:
+        def call(self, *args, **kwargs):
+            raise AssertionError("model_runner.call must not be invoked on empty schedule")
+
+    engine = object.__new__(LLMEngineBase)
+    engine.scheduler = sched
+    engine.model_runner = _Runner()
+
+    def _fail_preprocess(seq, is_prefill):
+        raise AssertionError("preprocess_seq must not be invoked on empty schedule")
+
+    def _fail_postprocess(seq, output, is_prefill):
+        raise AssertionError("postprocess_seq must not be invoked on empty schedule")
+
+    engine.preprocess_seq = _fail_preprocess
+    engine.postprocess_seq = _fail_postprocess
+
+    assert engine.step() == []


### PR DESCRIPTION
## problem

`Scheduler.schedule()` in the decode phase can legitimately return with `scheduled_seqs` empty. Two real-world triggers:

1. **kv pressure / decode self-preempt**: when the only running sequence has no KV headroom, the `while not can_append(seq)` loop falls into the `else: self.preempt(seq); break` branch. After the break, the outer `while self.running` loop exits immediately, leaving `scheduled_seqs == []`.
2. **cancel during step**: `Scheduler.cancel()` drains the scheduler between engine steps, eg when a websocket client disconnects mid-stream.

## repro (from production)

We serve Thai TTS with VoxCPM2 on `nano-vllm-voxcpm==2.0.0` from pypi. The 2.0.0 `Scheduler.schedule()` ended decode with `assert scheduled_seqs`, so trigger #2 very reliably crashed the inference subprocess on websocket client disconnect mid-stream. FastAPI parent stayed up (`/health=200`) while `/tts` hung forever on `queue_out.get()`.

## status in main

Main has already fixed this in 50cd51d (`fix: handle empty schedules after cancellation`): the assert is gone and `LLMEngineBase.step()` short-circuits on an empty schedule. Huge thanks for the fast turnaround — many thanks @zgy.

## what this PR adds

Existing tests cover:
- cancel emptying running + waiting blocked by `can_allocate` → `([], False)` (`test_scheduler_returns_empty_when_cancel_empties_running_and_waiting_cannot_fit`).
- engine `step()` short-circuits on an empty schedule via a mocked scheduler (`test_llm_engine_step_returns_on_empty_schedule_without_runner_call`).
- decode preempting *another* running seq to make room (`test_scheduler_preempts_other_running_sequence_when_decode_needs_capacity`).

Not directly covered: the decode **self-preempt** branch (`else: self.preempt(seq); break`), which is the specific code path that produced the production hang.

This PR adds one new file, `tests/unit/test_scheduler_empty_decode_batch.py`, with two focused tests:

1. `test_decode_self_preempt_returns_empty_without_crash` — drives a real `Scheduler` with `max_num_seqs=1`, admits one seq, monkeypatches `can_append` to False, asserts the next `schedule()` returns `([], False)`, leaves the seq in `waiting`, and empties `running`.
2. `test_engine_step_is_noop_when_decode_self_preempts` — wires `LLMEngineBase` to the same real scheduler and asserts `step()` is a no-op (never calls `preprocess_seq`, `postprocess_seq`, or `model_runner.call`). Complements the existing mock-based test by exercising the real schedule → step path end to end.

No code changes.

## notes

- We carried a local hot-patch on our fleet while main-without-release was the only fix: https://github.com/100x-fi/voxcpm-server/pull/1.
- Would v much appreciate a new pypi release after any follow-up lands, lots of 2.0.0 users are still hitting trigger #2 in particular.

## local test run

`pytest tests/unit/test_scheduler_empty_decode_batch.py tests/unit/test_scheduler.py` — 13 passed (2 new + 11 existing) on py3.11, cpu torch.