### PR TITLE
Handle starving and silent killing of recv queue under load.

### DIFF
--- a/nanovllm_voxcpm/models/voxcpm2/server.py
+++ b/nanovllm_voxcpm/models/voxcpm2/server.py
@@ -319,12 +319,15 @@ class AsyncVoxCPM2Server:
                 if res["type"] == "stream":
                     if res["id"] in self.stream_table:
                         await self.stream_table[res["id"]].put(res["data"])
+
                 elif res["id"] in self.op_table:
-                    if res["type"] == "response":
-                        self.op_table[res["id"]].set_result(res["data"] if "data" in res else None)
-                    else:
-                        self.op_table[res["id"]].set_exception(RuntimeError(res["error"]))
-                    del self.op_table[res["id"]]
+                    fut = self.op_table.pop(res["id"])
+                    if not fut.done():
+                        if res["type"] == "response":
+                            fut.set_result(res["data"] if "data" in res else None)
+                        else:
+                            fut.set_exception(RuntimeError(res["error"]))
+                    # else: future was cancelled (wait_for timeout etc) — skip set_result silently
         except asyncio.CancelledError:
             return
 
@@ -333,7 +336,10 @@ class AsyncVoxCPM2Server:
         loop = asyncio.get_running_loop()
         fut: asyncio.Future[Any] = loop.create_future()
         self.op_table[op_id] = fut
-        await asyncio.to_thread(self.queue_in.put, {"id": op_id, "type": cmd, "args": args, "kwargs": kwargs})
+        # queue_in is unbounded (maxsize=0); put_nowait() is instant and does not
+        # consume a thread pool slot. asyncio.to_thread() here starves recv_queue
+        # under high concurrent load.
+        self.queue_in.put_nowait({"id": op_id, "type": cmd, "args": args, "kwargs": kwargs})
         return await fut
 
     async def health(self) -> HealthResponse:


### PR DESCRIPTION
Two independent bugs in AsyncVoxCPM2Server that each cause the server to stop
processing requests under production load.

## Bug 1 — Thread pool deadlock in `submit()`

`submit()` called `await asyncio.to_thread(self.queue_in.put, item)` to send
commands to the subprocess. `submit()` is called for every operation —
add_request, cancel, get_model_info, health, and others. Under concurrent load,
many coroutines can be in `submit()` simultaneously, each occupying a slot in
Python's default asyncio thread pool (~6 slots, min(32, cpu_count + 4)).

`recv_queue` also uses `await asyncio.to_thread(self.queue_out.get, timeout=1)`
on the same pool. With the pool saturated by concurrent submit() callers,
recv_queue cannot get a thread slot to drain queue_out. Pending futures never
resolve, health checks time out.

Fix: `queue_in` is created with `maxsize=0` (unbounded). `put_nowait()` appends
to the queue's internal deque and returns immediately without consuming a thread
pool slot. The queue's background feeder thread drains the deque to the pipe
independently.


## Bug 2 — `recv_queue` silent death via `InvalidStateError`

`submit()` creates a Future and stores it in `op_table`, then awaits it waiting
for the subprocess to respond. If the caller of `submit()` is cancelled or times
out before the subprocess responds (e.g. via `asyncio.wait_for`, task
cancellation, or any other reason), the Future transitions to CANCELLED state
but remains in `op_table`.

When the subprocess eventually responds, `recv_queue` finds the op_id in
`op_table` and calls `set_result()` on the already-cancelled future, which raises
`asyncio.exceptions.InvalidStateError`. The outer try/except only caught
`CancelledError`, so `InvalidStateError` propagated and killed the recv_queue
task. `asyncio.Task` stores the unhandled exception silently — nothing drained
`queue_out` from that point, all subsequent requests stalled.

Fix: check `fut.done()` before resolving. If the future is already done
(cancelled or otherwise), skip set_result and delete from op_table. The
original caller has already received its cancellation, so dropping the late
response is correct.


## Changes

- `nanovllm_voxcpm/models/voxcpm2/server.py`
  - `submit()`: replace `asyncio.to_thread(queue_in.put, ...)` with `queue_in.put_nowait(...)`
  - `recv_queue()`: guard `set_result`/`set_exception` with `if not fut.done()`


P.S.
Took AI's help to draft and explain the issue clearly in PR. 