### PR TITLE
Fix default executor starvation in streaming paths

### DIFF
--- a/deployment/app/services/mp3.py
+++ b/deployment/app/services/mp3.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import queue
 import threading
 import time
@@ -39,6 +40,18 @@ async def stream_mp3(
     mp3_q: queue.Queue[bytes | None] = queue.Queue(maxsize=8)
     stop_evt = threading.Event()
     thread_exc: list[BaseException] = []
+    loop = asyncio.get_running_loop()
+    io_executor = concurrent.futures.ThreadPoolExecutor(max_workers=2, thread_name_prefix="mp3-queue")
+
+    async def put_pcm(item: np.ndarray | None) -> None:
+        await loop.run_in_executor(io_executor, pcm_q.put, item)
+
+    def drain_queue(q: queue.Queue) -> None:
+        while True:
+            try:
+                q.get_nowait()
+            except queue.Empty:
+                return
 
     def encoder_thread() -> None:
         try:
@@ -95,10 +108,10 @@ async def stream_mp3(
                 if await request.is_disconnected():
                     stop_evt.set()
                     break
-                await asyncio.to_thread(pcm_q.put, chunk)
+                await put_pcm(chunk)
         finally:
             try:
-                await asyncio.to_thread(pcm_q.put, None)
+                await put_pcm(None)
             except Exception:
                 pass
 
@@ -106,7 +119,7 @@ async def stream_mp3(
 
     try:
         while True:
-            item = await asyncio.to_thread(mp3_q.get)
+            item = await loop.run_in_executor(io_executor, mp3_q.get)
             if item is None:
                 break
             yield item
@@ -115,6 +128,16 @@ async def stream_mp3(
     finally:
         stop_evt.set()
         producer_task.cancel()
+        drain_queue(pcm_q)
+        drain_queue(mp3_q)
+        try:
+            pcm_q.put_nowait(None)
+        except Exception:
+            pass
+        try:
+            mp3_q.put_nowait(None)
+        except Exception:
+            pass
         try:
             await producer_task
         except asyncio.CancelledError:
@@ -122,7 +145,6 @@ async def stream_mp3(
         except Exception:
             pass
         try:
-            await asyncio.to_thread(pcm_q.put, None)
-        except Exception:
-            pass
-        await asyncio.to_thread(enc_thread.join, 2.0)
+            await loop.run_in_executor(io_executor, enc_thread.join, 2.0)
+        finally:
+            io_executor.shutdown(wait=True, cancel_futures=True)

--- a/deployment/tests/test_services_mp3.py
+++ b/deployment/tests/test_services_mp3.py
@@ -1,5 +1,8 @@
 import asyncio
+import concurrent.futures
 import sys
+import threading
+import types
 from pathlib import Path
 
 import pytest
@@ -154,3 +157,112 @@ def test_stream_mp3_raises_if_pcm_conversion_fails(monkeypatch):
     with pytest.raises(RuntimeError, match="MP3 encoder failed"):
         asyncio.run(run())
     assert dummy_ctr.count == 1
+
+
+def test_stream_mp3_survives_default_executor_starvation(monkeypatch):
+    from app.core.config import Mp3Config
+    import app.services.mp3 as mp3
+
+    class FakeEncoder:
+        def set_bit_rate(self, value):
+            pass
+
+        def set_in_sample_rate(self, value):
+            pass
+
+        def set_channels(self, value):
+            pass
+
+        def set_quality(self, value):
+            pass
+
+        def encode(self, pcm_bytes):
+            return b"frame" if pcm_bytes else b""
+
+        def flush(self):
+            return b"flush"
+
+    monkeypatch.setitem(sys.modules, "lameenc", types.SimpleNamespace(Encoder=FakeEncoder))
+    monkeypatch.setattr(mp3, "AUDIO_ENCODE_SECONDS", _DummyHistogram())
+    monkeypatch.setattr(mp3, "AUDIO_ENCODE_FAILURES_TOTAL", _DummyCounter())
+
+    chunks = [np.zeros((128,), dtype=np.float32) for _ in range(2)]
+
+    async def run() -> bytes:
+        loop = asyncio.get_running_loop()
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        loop.set_default_executor(executor)
+        unblock_executor = threading.Event()
+        executor_blocker = loop.run_in_executor(executor, unblock_executor.wait)
+        await asyncio.sleep(0)
+
+        try:
+            out: list[bytes] = []
+            async for b in mp3.stream_mp3(
+                request=_FakeRequest(),
+                wav_chunks=_agen(chunks),
+                sample_rate=16000,
+                mp3=Mp3Config(bitrate_kbps=128, quality=2),
+            ):
+                out.append(b)
+            return b"".join(out)
+        finally:
+            unblock_executor.set()
+            await executor_blocker
+            executor.shutdown(wait=True)
+
+    data = asyncio.run(asyncio.wait_for(run(), timeout=1.0))
+    assert data == b"frameframeflush"
+
+
+def test_stream_mp3_close_cleans_up_threads(monkeypatch):
+    from app.core.config import Mp3Config
+    import app.services.mp3 as mp3
+
+    class FakeEncoder:
+        def set_bit_rate(self, value):
+            pass
+
+        def set_in_sample_rate(self, value):
+            pass
+
+        def set_channels(self, value):
+            pass
+
+        def set_quality(self, value):
+            pass
+
+        def encode(self, pcm_bytes):
+            return b"frame" if pcm_bytes else b""
+
+        def flush(self):
+            return b"flush"
+
+    def live_mp3_threads() -> set[int | None]:
+        return {
+            thread.ident
+            for thread in threading.enumerate()
+            if thread.is_alive() and (thread.name == "mp3-encoder" or thread.name.startswith("mp3-queue"))
+        }
+
+    monkeypatch.setitem(sys.modules, "lameenc", types.SimpleNamespace(Encoder=FakeEncoder))
+    monkeypatch.setattr(mp3, "AUDIO_ENCODE_SECONDS", _DummyHistogram())
+    monkeypatch.setattr(mp3, "AUDIO_ENCODE_FAILURES_TOTAL", _DummyCounter())
+
+    chunks = [np.zeros((128,), dtype=np.float32) for _ in range(32)]
+    before = live_mp3_threads()
+
+    async def run() -> bytes:
+        stream = mp3.stream_mp3(
+            request=_FakeRequest(),
+            wav_chunks=_agen(chunks),
+            sample_rate=16000,
+            mp3=Mp3Config(bitrate_kbps=128, quality=2),
+        )
+        try:
+            return await anext(stream)
+        finally:
+            await stream.aclose()
+
+    assert asyncio.run(asyncio.wait_for(run(), timeout=1.0)) == b"frame"
+    assert live_mp3_threads() == before

--- a/nanovllm_voxcpm/models/voxcpm/server.py
+++ b/nanovllm_voxcpm/models/voxcpm/server.py
@@ -10,6 +10,7 @@ import torch.multiprocessing as mp
 from queue import Empty
 import traceback
 import uuid
+import threading
 import torchaudio
 import io
 import time
@@ -341,17 +342,36 @@ class AsyncVoxCPMServer:
         loop = asyncio.get_running_loop()
         self._init_fut: asyncio.Future[None] = loop.create_future()
 
-        self.recv_task: asyncio.Task = asyncio.create_task(self.recv_queue())
         self.op_table: dict[str, asyncio.Future[Any]] = {}
         self.stream_table: dict[str, asyncio.Queue[Waveform | None]] = {}
+        self._queue_out_async: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self._queue_out_stop = threading.Event()
+        self._queue_out_thread = threading.Thread(
+            target=self._queue_out_bridge,
+            args=(loop,),
+            name="voxcpm-queue-out",
+            daemon=True,
+        )
+        self._queue_out_thread.start()
+        self.recv_task: asyncio.Task = asyncio.create_task(self.recv_queue())
+
+    def _queue_out_bridge(self, loop: asyncio.AbstractEventLoop) -> None:
+        while not self._queue_out_stop.is_set():
+            try:
+                res = self.queue_out.get(timeout=0.1)
+            except Empty:
+                continue
+            except (EOFError, OSError, ValueError):
+                return
+            try:
+                loop.call_soon_threadsafe(self._queue_out_async.put_nowait, res)
+            except RuntimeError:
+                return
 
     async def recv_queue(self) -> None:
         try:
             while True:
-                try:
-                    res = await asyncio.to_thread(self.queue_out.get, timeout=1)
-                except Empty:
-                    continue
+                res = await self._queue_out_async.get()
 
                 # Init handshake (sent once at process startup).
                 if res.get("type") == "init_ok":
@@ -370,12 +390,12 @@ class AsyncVoxCPMServer:
                     else:
                         print(f"Unknown stream_id: {res['id']}")
                 elif res["id"] in self.op_table:
-                    if res["type"] == "response":
-                        self.op_table[res["id"]].set_result(res["data"] if "data" in res else None)
-                        del self.op_table[res["id"]]
-                    else:
-                        self.op_table[res["id"]].set_exception(RuntimeError(res["error"]))
-                        del self.op_table[res["id"]]
+                    fut = self.op_table.pop(res["id"])
+                    if not fut.done():
+                        if res["type"] == "response":
+                            fut.set_result(res["data"] if "data" in res else None)
+                        else:
+                            fut.set_exception(RuntimeError(res["error"]))
                 else:
                     print(f"Unknown op_id: {res['id']}")
         except asyncio.CancelledError:
@@ -390,15 +410,7 @@ class AsyncVoxCPMServer:
 
         self.op_table[op_id] = fut
 
-        await asyncio.to_thread(
-            self.queue_in.put,
-            {
-                "id": op_id,
-                "type": cmd,
-                "args": args,
-                "kwargs": kwargs,
-            },
-        )
+        self.queue_in.put_nowait({"id": op_id, "type": cmd, "args": args, "kwargs": kwargs})
         return await fut
 
     async def health(self) -> HealthResponse:
@@ -435,11 +447,10 @@ class AsyncVoxCPMServer:
                 pass
 
         self.recv_task.cancel()
-        # Ensure the background receiver task is actually done before closing queues.
-        # Cancellation may race with the underlying to_thread() call.
-        # In Python 3.10+, asyncio.CancelledError may not be an Exception.
         with contextlib.suppress(asyncio.CancelledError):
             await self.recv_task
+        self._queue_out_stop.set()
+        self._queue_out_thread.join(timeout=1.0)
 
         # If the child acknowledged stop, give it a chance to exit cleanly
         # before we escalate to terminate/kill.

--- a/nanovllm_voxcpm/models/voxcpm2/server.py
+++ b/nanovllm_voxcpm/models/voxcpm2/server.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import io
 import os
+import threading
 import time
 import traceback
 import uuid
@@ -295,17 +296,36 @@ class AsyncVoxCPM2Server:
         self.process.start()
         loop = asyncio.get_running_loop()
         self._init_fut: asyncio.Future[None] = loop.create_future()
-        self.recv_task: asyncio.Task = asyncio.create_task(self.recv_queue())
         self.op_table: dict[str, asyncio.Future[Any]] = {}
         self.stream_table: dict[str, asyncio.Queue[Waveform | None]] = {}
+        self._queue_out_async: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self._queue_out_stop = threading.Event()
+        self._queue_out_thread = threading.Thread(
+            target=self._queue_out_bridge,
+            args=(loop,),
+            name="voxcpm2-queue-out",
+            daemon=True,
+        )
+        self._queue_out_thread.start()
+        self.recv_task: asyncio.Task = asyncio.create_task(self.recv_queue())
+
+    def _queue_out_bridge(self, loop: asyncio.AbstractEventLoop) -> None:
+        while not self._queue_out_stop.is_set():
+            try:
+                res = self.queue_out.get(timeout=0.1)
+            except Empty:
+                continue
+            except (EOFError, OSError, ValueError):
+                return
+            try:
+                loop.call_soon_threadsafe(self._queue_out_async.put_nowait, res)
+            except RuntimeError:
+                return
 
     async def recv_queue(self) -> None:
         try:
             while True:
-                try:
-                    res = await asyncio.to_thread(self.queue_out.get, timeout=1)
-                except Empty:
-                    continue
+                res = await self._queue_out_async.get()
 
                 if res.get("type") == "init_ok":
                     if not self._init_fut.done():
@@ -374,6 +394,8 @@ class AsyncVoxCPM2Server:
         self.recv_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await self.recv_task
+        self._queue_out_stop.set()
+        self._queue_out_thread.join(timeout=1.0)
         if graceful_stop and self.process.is_alive():
             await asyncio.to_thread(self.process.join, 5.0)
         if self.process.is_alive():

--- a/tests/unit/test_core_server_threadpool_starvation.py
+++ b/tests/unit/test_core_server_threadpool_starvation.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import contextlib
+import json
+import queue
+import signal
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakeLLM:
+    feat_dim = 4
+    patch_size = 2
+
+    def __init__(self, config):
+        self.model_runner = SimpleNamespace(vae=SimpleNamespace(sample_rate=16000, out_sample_rate=24000))
+
+    def is_finished(self):
+        return True
+
+    def step(self):
+        return []
+
+    def list_loras(self):
+        return []
+
+
+def _patch_voxcpm2_fake_llm(monkeypatch):
+    import nanovllm_voxcpm.models.voxcpm2.server as server_mod
+
+    monkeypatch.setattr(server_mod, "VoxCPM2Engine", _FakeLLM)
+    monkeypatch.setattr(server_mod.VoxCPM2Config, "model_validate_json", lambda raw: SimpleNamespace())
+    return server_mod, server_mod.AsyncVoxCPM2Server
+
+
+def _patch_voxcpm_fake_llm(monkeypatch):
+    import nanovllm_voxcpm.models.voxcpm.server as server_mod
+
+    monkeypatch.setattr(server_mod, "VoxCPMEngine", _FakeLLM)
+    monkeypatch.setattr(server_mod.VoxCPMConfig, "model_validate_json", lambda raw: SimpleNamespace())
+    return server_mod, server_mod.AsyncVoxCPMServer
+
+
+class _ThreadProcess:
+    def __init__(self, target, args, kwargs=None, daemon=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+        self.daemon = daemon
+        self.exitcode = None
+        self._thread = threading.Thread(target=self._run, daemon=daemon)
+
+    def _run(self):
+        try:
+            self._target(*self._args, **self._kwargs)
+            self.exitcode = 0
+        except BaseException:
+            self.exitcode = 1
+            raise
+
+    def start(self):
+        self._thread.start()
+
+    def is_alive(self):
+        return self._thread.is_alive()
+
+    def join(self, timeout=None):
+        self._thread.join(timeout=timeout)
+
+    def terminate(self):
+        self.exitcode = -15
+
+    def kill(self):
+        self.exitcode = -9
+
+
+class _ThreadContext:
+    Queue = queue.Queue
+    Process = _ThreadProcess
+
+
+async def _exercise_control_plane_while_default_executor_is_saturated(server_mod, async_server_cls, model_path):
+    loop = asyncio.get_running_loop()
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    loop.set_default_executor(executor)
+
+    unblock_executor = threading.Event()
+    executor_blocker = loop.run_in_executor(executor, unblock_executor.wait)
+    await asyncio.sleep(0)
+
+    server = async_server_cls(model_path=str(model_path))
+
+    try:
+        await asyncio.wait_for(server.get_model_info(), timeout=0.2)
+    finally:
+        server.queue_in.put({"id": "stop", "type": "stop", "args": (), "kwargs": {}})
+        server.queue_out.put({"type": "response", "id": "unused", "data": None})
+        server.recv_task.cancel()
+        unblock_executor.set()
+        with contextlib.suppress(asyncio.CancelledError):
+            await server.recv_task
+        await executor_blocker
+        server.process.join(timeout=1.0)
+        assert not server.process.is_alive()
+
+
+@pytest.mark.xfail(
+    reason="recv_queue must not depend on the default asyncio executor under load",
+    raises=asyncio.TimeoutError,
+    strict=True,
+)
+def test_voxcpm2_control_plane_survives_default_executor_starvation(monkeypatch, tmp_path):
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    (model_path / "config.json").write_text(json.dumps({}), encoding="utf-8")
+    server_mod, async_server_cls = _patch_voxcpm2_fake_llm(monkeypatch)
+    monkeypatch.setattr(server_mod.mp, "get_context", lambda method: _ThreadContext())
+    monkeypatch.setattr(signal, "signal", lambda *args: None)
+
+    asyncio.run(_exercise_control_plane_while_default_executor_is_saturated(server_mod, async_server_cls, model_path))
+
+
+@pytest.mark.xfail(
+    reason="submit and recv_queue must not depend on the default asyncio executor under load",
+    raises=asyncio.TimeoutError,
+    strict=True,
+)
+def test_voxcpm_control_plane_survives_default_executor_starvation(monkeypatch, tmp_path):
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    (model_path / "config.json").write_text(json.dumps({}), encoding="utf-8")
+    server_mod, async_server_cls = _patch_voxcpm_fake_llm(monkeypatch)
+    monkeypatch.setattr(server_mod.mp, "get_context", lambda method: _ThreadContext())
+    monkeypatch.setattr(signal, "signal", lambda *args: None)
+
+    asyncio.run(_exercise_control_plane_while_default_executor_is_saturated(server_mod, async_server_cls, model_path))

--- a/tests/unit/test_core_server_threadpool_starvation.py
+++ b/tests/unit/test_core_server_threadpool_starvation.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
-import contextlib
 import json
 import queue
 import signal
 import threading
 from types import SimpleNamespace
-
-import pytest
 
 
 class _FakeLLM:
@@ -95,24 +92,15 @@ async def _exercise_control_plane_while_default_executor_is_saturated(server_mod
     server = async_server_cls(model_path=str(model_path))
 
     try:
+        await asyncio.wait_for(server.wait_for_ready(), timeout=0.2)
         await asyncio.wait_for(server.get_model_info(), timeout=0.2)
     finally:
-        server.queue_in.put({"id": "stop", "type": "stop", "args": (), "kwargs": {}})
-        server.queue_out.put({"type": "response", "id": "unused", "data": None})
-        server.recv_task.cancel()
         unblock_executor.set()
-        with contextlib.suppress(asyncio.CancelledError):
-            await server.recv_task
         await executor_blocker
-        server.process.join(timeout=1.0)
+        await server.stop()
         assert not server.process.is_alive()
 
 
-@pytest.mark.xfail(
-    reason="recv_queue must not depend on the default asyncio executor under load",
-    raises=asyncio.TimeoutError,
-    strict=True,
-)
 def test_voxcpm2_control_plane_survives_default_executor_starvation(monkeypatch, tmp_path):
     model_path = tmp_path / "model"
     model_path.mkdir()
@@ -124,11 +112,6 @@ def test_voxcpm2_control_plane_survives_default_executor_starvation(monkeypatch,
     asyncio.run(_exercise_control_plane_while_default_executor_is_saturated(server_mod, async_server_cls, model_path))
 
 
-@pytest.mark.xfail(
-    reason="submit and recv_queue must not depend on the default asyncio executor under load",
-    raises=asyncio.TimeoutError,
-    strict=True,
-)
 def test_voxcpm_control_plane_survives_default_executor_starvation(monkeypatch, tmp_path):
     model_path = tmp_path / "model"
     model_path.mkdir()


### PR DESCRIPTION
Closes #52.

## Problem

The service could deadlock under concurrent streaming `/generate` requests because multiple blocking queue operations were scheduled on asyncio's default thread pool:

- `stream_mp3()` used the default executor for bounded PCM input and MP3 output queues. Each active stream could hold default executor workers for long blocking waits.
- Core server dispatchers also depended on the same default executor for `queue_out.get()`. When the default pool was saturated, responses from the inference subprocess were no longer drained.
- In the older VoxCPM server path, `submit()` still used the default executor for `queue_in.put()`, and late responses could complete already-cancelled futures without checking `done()`.

The failure mode was service-wide: streaming responses could hang, control-plane calls such as `/info` and `/encode_latents` could stop resolving, and cleanup/cancel paths could also block behind the same starved executor.

## Design

This fix avoids increasing the default executor size and instead removes critical blocking queue work from it:

- Keep the core dispatcher independent from the default executor by using a dedicated `queue_out` bridge thread per async server.
- Preserve the existing server response dispatch contract: init handshake, stream chunks, operation futures, and cancelled-future handling all remain in the event loop.
- Align the older VoxCPM async server with the VoxCPM2 safety fixes by using non-blocking `queue_in.put_nowait()` and guarding future completion with `fut.done()`.
- Preserve MP3 bounded-queue backpressure while isolating its blocking queue operations in a per-stream private executor instead of the loop default executor.

## Implementation

- Added dedicated `queue_out` bridge threads in both `AsyncVoxCPMServer` and `AsyncVoxCPM2Server`; `recv_queue()` now consumes from an `asyncio.Queue` populated via `loop.call_soon_threadsafe()`.
- Updated the older VoxCPM `submit()` path to use `put_nowait()` and to safely drop late responses for futures that were already cancelled or completed.
- Reworked `stream_mp3()` so `pcm_q.put`, `mp3_q.get`, and encoder thread joining use a private `ThreadPoolExecutor(max_workers=2)` per stream, leaving the default executor available for unrelated service work.
- Hardened MP3 cleanup by cancelling the producer, draining bounded queues, sending sentinels, joining the encoder, and shutting down the private executor.
- Added regression tests that saturate the default executor and verify core control-plane calls and MP3 streaming still complete.

## Testing

- `uv run pytest tests/unit/test_core_server_threadpool_starvation.py -q`
- `uv run pytest tests/unit/test_voxcpm_serverpool_lora_api.py tests/unit/test_voxcpm2_serverpool_lora_api.py tests/unit/test_core_server_threadpool_starvation.py -q`
- `uv run pytest deployment/tests/test_services_mp3.py -q`
- `uv run pytest deployment/tests/test_deployment_app.py deployment/tests/test_routes_additional_coverage.py deployment/tests/test_services_mp3.py -q`
- `uv run black --check nanovllm_voxcpm/models/voxcpm/server.py nanovllm_voxcpm/models/voxcpm2/server.py tests/unit/test_core_server_threadpool_starvation.py deployment/app/services/mp3.py deployment/tests/test_services_mp3.py`
- `uv run python -m compileall nanovllm_voxcpm/models/voxcpm/server.py nanovllm_voxcpm/models/voxcpm2/server.py tests/unit/test_core_server_threadpool_starvation.py deployment/app/services/mp3.py deployment/tests/test_services_mp3.py`