### PR TITLE
fix(block_manager): prevent hash_to_block_id unbounded growth on deallocate

### DIFF
--- a/nanovllm_voxcpm/engine/block_manager.py
+++ b/nanovllm_voxcpm/engine/block_manager.py
@@ -117,7 +117,15 @@ class BlockManager:
         return self.blocks[block_id]
 
     def _deallocate_block(self, block_id: int) -> None:
-        assert self.blocks[block_id].ref_count == 0
+        block = self.blocks[block_id]
+        assert block.ref_count == 0
+        if block.hash != -1:
+            # Prevent unbounded growth of hash_to_block_id by removing stale
+            # entries for freed blocks.  Without this the dict accumulates one
+            # entry per unique KV-block prefix across the lifetime of the
+            # process, degrading forward-mapping speed and GC behaviour over
+            # long-running deployments (hours/days).
+            self.hash_to_block_id.pop(block.hash, None)
         self.used_block_ids.remove(block_id)
         self.free_block_ids.append(block_id)
 


### PR DESCRIPTION
## Summary

When a KV block is freed via `_deallocate_block`, its hash was never removed from `hash_to_block_id`. Over long-running deployments (hours/days of continuous TTS inference) this dict grows by one entry per unique KV-block prefix that ever existed, slowly degrading hash-lookup speed and Python GC performance.

Reported in: #61, #58

## The Fix

Pop the stale `block.hash` entry from `hash_to_block_id` when the block is freed. This is a 1-line semantic change (expanded with a guard + comment for clarity).

## Safety Analysis

The operation is safe because a freed block has:
- `ref_count == 0` — no sequence references it
- `token_ids == []` — cleared by `Block.reset()`

When `allocate()` later searches `hash_to_block_id` for a cache hit, the hit entrys block will have empty `token_ids`, so the `token_ids != token_ids` comparison (line 135) will force a cache miss — the same behaviour as before. The only difference is that we now proactively remove the stale dead entry instead of letting it accumulate.

In practice this means a freed blocks prefix can never trigger a future cache hit via its stale hash entry. But since `reset()` already cleared the content, such a hit would have been a false positive anyway (it would compare empty `[]` against real `token_ids` and still miss), so **there is zero behavioural change in cache-hit logic**.

## Context

This is part of a family of long-running stability issues affecting VoxCPM2 + nano-vllm deployments on consumer GPUs. See also #58 (process unresponsive after days — ``block_id`` and ``list`` accumulation), #61 (progressive audio quality degradation under CUDA graphs + LoRA on Blackwell), and OpenBMB/VoxCPM#269 (cudagraph race on RTX 5090).

## Open Questions for Reviewers

- Should we also consider a periodic eviction policy for `hash_to_block_id` (e.g. LRU capped at N entries) for deployments with very high request volumes?
- Could the same leak class exist elsewhere (e.g. `lora_runtime` state, scheduler callbacks)?