### PR TITLE
feat: Add Seed Support for Reproducible and Deterministic Generation in VoxCPM and VoxCPM2

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -5,7 +5,7 @@ End-to-end inference benchmarking for VoxCPM.
 ## Run
 
 ```bash
-uv run python benchmark/bench_inference.py --model ~/VoxCPM1.5 --concurrency 4 --iters 5 --warmup 1
+uv run python benchmark/bench_inference.py --model ~/VoxCPM1.5 --concurrency 4 --iters 5 --warmup 1 --seed 42
 ```
 
 Fixed-RPS TTFB (open-loop) for long-audio load:
@@ -31,6 +31,7 @@ Key flags:
 - `--devices`: CUDA devices, e.g. `0` or `0,1`
 - `--json-out`: write machine-readable results
 - `--max-loras`: enable LoRA when greater than `0` and register that many aliases from `--lora-path`
+- `--seed`: optional fixed random seed for reproducible generation
 
 Closed-loop "N users" benchmark (each user sends the next request immediately after the previous finishes):
 

--- a/benchmark/bench_closed_loop_users.py
+++ b/benchmark/bench_closed_loop_users.py
@@ -488,6 +488,7 @@ async def _consume_one_in_process(
     temperature: float,
     cfg_value: float,
     lora_name: str | None,
+    seed: int | None,
 ) -> tuple[float, float, int]:
     """Return: ttfb_s, wall_s, total_samples."""
 
@@ -501,6 +502,7 @@ async def _consume_one_in_process(
         temperature=temperature,
         cfg_value=cfg_value,
         lora_name=lora_name,
+        seed=seed
     ):
         if first_chunk_t is None:
             first_chunk_t = time.perf_counter()
@@ -567,6 +569,7 @@ async def async_main(argv: list[str] | None = None) -> int:
     p.add_argument("--max-generate-length", type=int, default=8000)
     p.add_argument("--temperature", type=float, default=1.0)
     p.add_argument("--cfg-value", type=float, default=2.0)
+    p.add_argument("--seed", type=int, default=None, help="Optional: fixed seed for generation")
     add_lora_args(p)
 
     p.add_argument(
@@ -675,6 +678,7 @@ async def async_main(argv: list[str] | None = None) -> int:
                             "max_generate_length": int(args.max_generate_length),
                             "temperature": float(args.temperature),
                             "cfg_value": float(args.cfg_value),
+                            "seed": args.seed,
                         },
                         lora_name,
                     ),
@@ -712,6 +716,7 @@ async def async_main(argv: list[str] | None = None) -> int:
                     temperature=float(args.temperature),
                     cfg_value=float(args.cfg_value),
                     lora_name=choose_lora_name(lora_names, lora_rng),
+                    seed=args.seed,
                 )
                 audio_s = (total_samples / float(sample_rate)) if (sample_rate and sample_rate > 0) else None
                 rtf = _rtf_excluding_ttfb(wall_s, ttfb_s, audio_s) if (audio_s is not None and audio_s > 0) else None

--- a/benchmark/bench_closed_loop_users.py
+++ b/benchmark/bench_closed_loop_users.py
@@ -502,7 +502,7 @@ async def _consume_one_in_process(
         temperature=temperature,
         cfg_value=cfg_value,
         lora_name=lora_name,
-        seed=seed
+        seed=seed,
     ):
         if first_chunk_t is None:
             first_chunk_t = time.perf_counter()

--- a/benchmark/bench_inference.py
+++ b/benchmark/bench_inference.py
@@ -100,6 +100,7 @@ async def _consume_one(
     temperature: float,
     cfg_value: float,
     lora_name: str | None,
+    seed: int | None,
 ) -> OneRequestResult:
     start = time.perf_counter()
     first_chunk_t = None
@@ -112,6 +113,7 @@ async def _consume_one(
         temperature=temperature,
         cfg_value=cfg_value,
         lora_name=lora_name,
+        seed=seed
     ):
         if first_chunk_t is None:
             first_chunk_t = time.perf_counter()
@@ -163,6 +165,7 @@ async def _run_iteration(
     sample_rate: int | None,
     lora_names: list[str],
     lora_rng: Any,
+    seed: int | None,
 ) -> IterationResult:
     start = time.perf_counter()
     tasks = [
@@ -174,6 +177,7 @@ async def _run_iteration(
                 temperature=temperature,
                 cfg_value=cfg_value,
                 lora_name=choose_lora_name(lora_names, lora_rng),
+                seed=seed,
             )
         )
         for _ in range(concurrency)
@@ -275,6 +279,7 @@ async def async_main(argv: list[str] | None = None) -> int:
     p.add_argument("--max-generate-length", type=int, default=2000)
     p.add_argument("--temperature", type=float, default=1.0)
     p.add_argument("--cfg-value", type=float, default=2.0)
+    p.add_argument("--seed", type=int, default=None, help="Optional: fixed seed for generation")
     add_lora_args(p)
 
     p.add_argument("--concurrency", type=int, default=1, help="Number of concurrent requests")
@@ -370,6 +375,7 @@ async def async_main(argv: list[str] | None = None) -> int:
                 sample_rate=sample_rate,
                 lora_names=lora_names,
                 lora_rng=lora_rng,
+                seed=args.seed,
             )
 
         # Measure
@@ -385,6 +391,7 @@ async def async_main(argv: list[str] | None = None) -> int:
                     sample_rate=sample_rate,
                     lora_names=lora_names,
                     lora_rng=lora_rng,
+                    seed=args.seed,
                 )
             )
     finally:

--- a/benchmark/bench_inference.py
+++ b/benchmark/bench_inference.py
@@ -113,7 +113,7 @@ async def _consume_one(
         temperature=temperature,
         cfg_value=cfg_value,
         lora_name=lora_name,
-        seed=seed
+        seed=seed,
     ):
         if first_chunk_t is None:
             first_chunk_t = time.perf_counter()

--- a/benchmark/bench_open_loop_users.py
+++ b/benchmark/bench_open_loop_users.py
@@ -130,6 +130,7 @@ async def _consume_one(
     cfg_value: float,
     scheduled_t: float,
     lora_name: str | None,
+    seed: int | None,
 ) -> OneRequestResult:
     started_t = time.perf_counter()
     first_chunk_t: float | None = None
@@ -142,6 +143,7 @@ async def _consume_one(
             temperature=temperature,
             cfg_value=cfg_value,
             lora_name=lora_name,
+            seed=seed,
         ):
             if first_chunk_t is None:
                 first_chunk_t = time.perf_counter()
@@ -320,6 +322,7 @@ async def async_main(argv: list[str] | None = None) -> int:
     p.add_argument("--max-generate-length", type=int, default=8000)
     p.add_argument("--temperature", type=float, default=1.0)
     p.add_argument("--cfg-value", type=float, default=2.0)
+    p.add_argument("--seed", type=int, default=None, help="Optional: fixed seed for generation")
     add_lora_args(p)
 
     p.add_argument(
@@ -432,6 +435,7 @@ async def async_main(argv: list[str] | None = None) -> int:
                             "max_generate_length": int(args.max_generate_length),
                             "temperature": float(args.temperature),
                             "cfg_value": float(args.cfg_value),
+                            "seed": args.seed,
                         },
                         lora_name,
                     ),
@@ -460,6 +464,7 @@ async def async_main(argv: list[str] | None = None) -> int:
                 cfg_value=args.cfg_value,
                 scheduled_t=scheduled_t,
                 lora_name=choose_lora_name(lora_names, lora_rng),
+                seed=args.seed,
             )
         finally:
             inflight.release()
@@ -516,6 +521,7 @@ async def async_main(argv: list[str] | None = None) -> int:
                                 "max_generate_length": int(max(1, min(args.max_generate_length, 500))),
                                 "temperature": float(args.temperature),
                                 "cfg_value": float(args.cfg_value),
+                                "seed": args.seed,
                             },
                             lora_name,
                         ),
@@ -532,6 +538,7 @@ async def async_main(argv: list[str] | None = None) -> int:
                         cfg_value=args.cfg_value,
                         scheduled_t=time.perf_counter(),
                         lora_name=choose_lora_name(lora_names, lora_rng),
+                        seed=args.seed,
                     )
 
         # Measurement scheduling.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -180,6 +180,11 @@ Request body (JSON):
 - Reference audio (optional, mutually exclusive):
   - wav reference: `ref_audio_wav_base64` + `ref_audio_wav_format`
   - latents reference: `ref_audio_latents_base64`
+- Additional options (optional):
+  - `seed`: optional fixed random seed for reproducible generation (int)
+  - `cfg_value`: classifier-free guidance scale (float, default: `1.5`)
+  - `temperature`: sampling temperature (float, default: `1.0`)
+  - `max_generate_length`: maximum number of model generation steps (int, default: `2000`)
 
 `ref_audio_*` is independent from the prompt fields, so you can combine reference audio with either zero-shot or prompted generation.
 

--- a/deployment/app/api/routes/generate.py
+++ b/deployment/app/api/routes/generate.py
@@ -170,16 +170,24 @@ async def generate(
         "max_generate_length": req.max_generate_length,
         "temperature": req.temperature,
         "cfg_value": req.cfg_value,
-        "lora_name": req.lora_name,
-        "seed": req.seed,
+        "lora_name": req.lora_name,        
     }
+    
+    generate_params = inspect.signature(server.generate).parameters
+    
     if ref_audio_latents is not None:
         generate_kwargs["ref_audio_latents"] = ref_audio_latents
-
+    
     if ref_audio_latents is not None:
-        generate_params = inspect.signature(server.generate).parameters
         if "ref_audio_latents" not in generate_params:
             raise HTTPException(status_code=400, detail="Reference audio is not supported by the loaded model")
+
+    if req.seed is not None:
+        generate_kwargs["seed"] = req.seed
+    
+    if req.seed is not None:
+        if "seed" not in generate_params:
+            raise HTTPException(status_code=400, detail="Seed is not supported by the loaded model")
 
     stream = server.generate(**generate_kwargs)
 

--- a/deployment/app/api/routes/generate.py
+++ b/deployment/app/api/routes/generate.py
@@ -170,21 +170,21 @@ async def generate(
         "max_generate_length": req.max_generate_length,
         "temperature": req.temperature,
         "cfg_value": req.cfg_value,
-        "lora_name": req.lora_name,        
+        "lora_name": req.lora_name,
     }
-    
+
     generate_params = inspect.signature(server.generate).parameters
-    
+
     if ref_audio_latents is not None:
         generate_kwargs["ref_audio_latents"] = ref_audio_latents
-    
+
     if ref_audio_latents is not None:
         if "ref_audio_latents" not in generate_params:
             raise HTTPException(status_code=400, detail="Reference audio is not supported by the loaded model")
 
     if req.seed is not None:
         generate_kwargs["seed"] = req.seed
-    
+
     if req.seed is not None:
         if "seed" not in generate_params:
             raise HTTPException(status_code=400, detail="Seed is not supported by the loaded model")

--- a/deployment/app/api/routes/generate.py
+++ b/deployment/app/api/routes/generate.py
@@ -171,6 +171,7 @@ async def generate(
         "temperature": req.temperature,
         "cfg_value": req.cfg_value,
         "lora_name": req.lora_name,
+        "seed": req.seed,
     }
     if ref_audio_latents is not None:
         generate_kwargs["ref_audio_latents"] = ref_audio_latents

--- a/deployment/app/schemas/http.py
+++ b/deployment/app/schemas/http.py
@@ -171,3 +171,4 @@ class GenerateRequest(BaseModel):
     max_generate_length: int = Field(2000, ge=1, description="Maximum number of model generation steps.")
     temperature: float = Field(1.0, ge=0.0, description="Sampling temperature.")
     cfg_value: float = Field(1.5, ge=0.0, description="Classifier-free guidance scale.")
+    seed: int | None = Field(None, description="Random seed for generation.")

--- a/nanovllm_voxcpm/models/voxcpm/engine.py
+++ b/nanovllm_voxcpm/models/voxcpm/engine.py
@@ -26,6 +26,7 @@ class VoxCPMSeqPayload:
 
     decode_pad: np.ndarray | None = None
     max_generate_length: int | None = None
+    seed: int | None = None
 
 
 class VoxCPMEngine(LLMEngineBase):
@@ -71,6 +72,7 @@ class VoxCPMEngine(LLMEngineBase):
                     temperature=seq.custom_payload.temperature,
                     cfg_value=seq.custom_payload.cfg_value,
                     padding_decode=seq.custom_payload.decode_pad,
+                    seed=seq.custom_payload.seed,
                 ),
                 adapter_id=seq.adapter_id,
             )
@@ -87,6 +89,7 @@ class VoxCPMEngine(LLMEngineBase):
                     temperature=seq.custom_payload.temperature,
                     cfg_value=seq.custom_payload.cfg_value,
                     padding_decode=seq.custom_payload.decode_pad,
+                    seed=seq.custom_payload.seed,
                 ),
                 adapter_id=seq.adapter_id,
             )
@@ -130,6 +133,7 @@ class VoxCPMEngine(LLMEngineBase):
         temperature: float = 1.0,
         cfg_value: float = 1.0,
         lora_name: str | None = None,
+        seed: int | None = None,
     ):
         if max_generate_length < 1:
             raise ValueError(f"max_generate_length must be >= 1, got {max_generate_length}")
@@ -189,6 +193,7 @@ class VoxCPMEngine(LLMEngineBase):
                 cfg_value=cfg_value,
                 max_generate_length=max_generate_length,
                 generated_waveforms=[],
+                seed=seed,
             ),
             lora_name=lora_name,
             adapter_id=adapter_id,

--- a/nanovllm_voxcpm/models/voxcpm/engine.py
+++ b/nanovllm_voxcpm/models/voxcpm/engine.py
@@ -27,6 +27,7 @@ class VoxCPMSeqPayload:
     decode_pad: np.ndarray | None = None
     max_generate_length: int | None = None
     seed: int | None = None
+    seed_step: int = 0
 
 
 class VoxCPMEngine(LLMEngineBase):
@@ -73,6 +74,7 @@ class VoxCPMEngine(LLMEngineBase):
                     cfg_value=seq.custom_payload.cfg_value,
                     padding_decode=seq.custom_payload.decode_pad,
                     seed=seq.custom_payload.seed,
+                    seed_step=seq.custom_payload.seed_step,
                 ),
                 adapter_id=seq.adapter_id,
             )
@@ -90,6 +92,7 @@ class VoxCPMEngine(LLMEngineBase):
                     cfg_value=seq.custom_payload.cfg_value,
                     padding_decode=seq.custom_payload.decode_pad,
                     seed=seq.custom_payload.seed,
+                    seed_step=seq.custom_payload.seed_step,
                 ),
                 adapter_id=seq.adapter_id,
             )
@@ -104,6 +107,8 @@ class VoxCPMEngine(LLMEngineBase):
         seq.custom_payload.feats.append(latents[None])
         seq.custom_payload.text_tokens.append(0)
         seq.custom_payload.feat_masks.append(True)
+        if seq.custom_payload.seed is not None and seq.custom_payload.seed >= 0:
+            seq.custom_payload.seed_step += 1
 
         seq.custom_payload.generated_waveforms.append(waveforms)
 
@@ -194,6 +199,7 @@ class VoxCPMEngine(LLMEngineBase):
                 max_generate_length=max_generate_length,
                 generated_waveforms=[],
                 seed=seed,
+                seed_step=0,
             ),
             lora_name=lora_name,
             adapter_id=adapter_id,

--- a/nanovllm_voxcpm/models/voxcpm/model.py
+++ b/nanovllm_voxcpm/models/voxcpm/model.py
@@ -655,14 +655,14 @@ class UnifiedCFM(torch.nn.Module):
         """
         b, c = mu.shape
         t = self.patch_size
-       
+
         if z_noise is not None:
             z = z_noise
         else:
             z = torch.randn((b, self.in_channels, t), device=mu.device, dtype=mu.dtype)
 
-        z = z * temperature[:, None, None]        
-        t_span = torch.linspace(1, 0, self.inference_timesteps + 1, device=mu.device, dtype=mu.dtype)        
+        z = z * temperature[:, None, None]
+        t_span = torch.linspace(1, 0, self.inference_timesteps + 1, device=mu.device, dtype=mu.dtype)
         # Sway sampling strategy
         t_span = t_span + (torch.cos(torch.pi / 2 * t_span) - 1 + t_span)
 
@@ -904,7 +904,7 @@ class VoxCPMModel(nn.Module):
         feat_mask: torch.Tensor,
         temperature: torch.Tensor,
         cfg_value: torch.Tensor,
-        z_noise: torch.Tensor | None = None, 
+        z_noise: torch.Tensor | None = None,
     ):
         """
         text_tokens: [T]

--- a/nanovllm_voxcpm/models/voxcpm/model.py
+++ b/nanovllm_voxcpm/models/voxcpm/model.py
@@ -636,6 +636,7 @@ class UnifiedCFM(torch.nn.Module):
         cond: torch.Tensor,
         temperature: torch.Tensor,
         cfg_value: torch.Tensor,
+        z_noise: torch.Tensor | None = None,
     ):
         """Forward diffusion
 
@@ -646,6 +647,7 @@ class UnifiedCFM(torch.nn.Module):
             cond: Not used but kept for future purposes
             temperature (torch.Tensor): temperature for scaling noise. (batch_size,)
             cfg_value (torch.Tensor): cfg value for guidance. (batch_size,)
+            z_noise (torch.Tensor, optional): pre-generated seeded noise. (batch_size, in_channels, patch_size)
 
         Returns:
             sample: generated mel-spectrogram
@@ -653,9 +655,14 @@ class UnifiedCFM(torch.nn.Module):
         """
         b, c = mu.shape
         t = self.patch_size
-        z = torch.randn((b, self.in_channels, t), device=mu.device, dtype=mu.dtype) * temperature[:, None, None]
+       
+        if z_noise is not None:
+            z = z_noise
+        else:
+            z = torch.randn((b, self.in_channels, t), device=mu.device, dtype=mu.dtype)
 
-        t_span = torch.linspace(1, 0, self.inference_timesteps + 1, device=mu.device, dtype=mu.dtype)
+        z = z * temperature[:, None, None]        
+        t_span = torch.linspace(1, 0, self.inference_timesteps + 1, device=mu.device, dtype=mu.dtype)        
         # Sway sampling strategy
         t_span = t_span + (torch.cos(torch.pi / 2 * t_span) - 1 + t_span)
 
@@ -897,6 +904,7 @@ class VoxCPMModel(nn.Module):
         feat_mask: torch.Tensor,
         temperature: torch.Tensor,
         cfg_value: torch.Tensor,
+        z_noise: torch.Tensor | None = None, 
     ):
         """
         text_tokens: [T]
@@ -955,6 +963,7 @@ class VoxCPMModel(nn.Module):
             cond=prefix_feat_cond.transpose(1, 2).contiguous(),
             temperature=temperature,
             cfg_value=cfg_value,
+            z_noise=z_noise,
         ).transpose(1, 2)
 
         stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(dim=-1)

--- a/nanovllm_voxcpm/models/voxcpm/runner.py
+++ b/nanovllm_voxcpm/models/voxcpm/runner.py
@@ -5,6 +5,7 @@ from multiprocessing.synchronize import Event
 from nanovllm_voxcpm.config import Config
 from nanovllm_voxcpm.engine.model_runner import RunnerTask, BaseModelRunner
 from nanovllm_voxcpm.utils.loader import load_model
+from nanovllm_voxcpm.utils.seed import derive_step_seed
 from nanovllm_voxcpm.models.voxcpm.model import VoxCPMModel, VoxCPMConfig
 from nanovllm_voxcpm.layers.audio_vae import AudioVAE
 import numpy as np
@@ -26,6 +27,7 @@ class VoxCPMPayload:
     # (T, D)
     padding_decode: np.ndarray | None = None
     seed: int | None = None
+    seed_step: int = 0
 
 
 class VoxCPMRunner(BaseModelRunner):
@@ -113,7 +115,7 @@ class VoxCPMRunner(BaseModelRunner):
         feats = []
         feat_masks = []
         temperatures = []
-        cfg_values = []        
+        cfg_values = []
         for seq in seqs:
             payload: VoxCPMPayload = seq.custom_payload
             assert payload.text_tokens.shape[0] == payload.feats.shape[0]
@@ -124,7 +126,7 @@ class VoxCPMRunner(BaseModelRunner):
             feat_masks.append(payload.feat_masks)
 
             temperatures.append(payload.temperature)
-            cfg_values.append(payload.cfg_value)            
+            cfg_values.append(payload.cfg_value)
 
         inputs["text_tokens"] = torch.from_numpy(np.concatenate(text_tokens, axis=0)).cuda(non_blocking=True)
         inputs["feat"] = torch.from_numpy(np.concatenate(feats, axis=0)).cuda(non_blocking=True).to(self.dtype)
@@ -135,20 +137,25 @@ class VoxCPMRunner(BaseModelRunner):
         inputs["cfg_value"] = (
             torch.tensor(cfg_values, dtype=torch.float32, pin_memory=True).cuda(non_blocking=True).to(self.dtype)
         )
-        
-        # Generate z_noise for each sequence based on the seed value in the payload
         bsz = len(seqs)
-        z_noise = torch.empty((bsz, self.feat_dim, self.patch_size), dtype=self.dtype, device="cuda")
-        for i, seq in enumerate(seqs):
-            seed_val = seq.custom_payload.seed
-            if seed_val is not None and seed_val >= 0:
-                generator = torch.Generator(device="cuda").manual_seed(int(seed_val))
-            else:
-                generator = None        
-            z_noise[i] = torch.randn((self.feat_dim, self.patch_size), generator=generator, dtype=self.dtype, device="cuda")
-        
+        seeded_rows = [
+            (i, int(seq.custom_payload.seed), seq.custom_payload.seed_step)
+            for i, seq in enumerate(seqs)
+            if seq.custom_payload.seed is not None and seq.custom_payload.seed >= 0
+        ]
+        if len(seeded_rows) == bsz:
+            z_noise = torch.empty((bsz, self.feat_dim, self.patch_size), dtype=self.dtype, device="cuda")
+        else:
+            z_noise = torch.randn((bsz, self.feat_dim, self.patch_size), dtype=self.dtype, device="cuda")
+
+        for i, seed_val, seed_step in seeded_rows:
+            generator = torch.Generator(device="cuda").manual_seed(derive_step_seed(seed_val, seed_step))
+            z_noise[i] = torch.randn(
+                (self.feat_dim, self.patch_size), generator=generator, dtype=self.dtype, device="cuda"
+            )
+
         inputs["z_noise"] = z_noise
-        
+
         outputs = self.run_model(inputs, is_prefill)
         latents = outputs["latents"]
 

--- a/nanovllm_voxcpm/models/voxcpm/runner.py
+++ b/nanovllm_voxcpm/models/voxcpm/runner.py
@@ -25,6 +25,7 @@ class VoxCPMPayload:
 
     # (T, D)
     padding_decode: np.ndarray | None = None
+    seed: int | None = None
 
 
 class VoxCPMRunner(BaseModelRunner):
@@ -71,6 +72,7 @@ class VoxCPMRunner(BaseModelRunner):
             "feat_mask": torch.zeros(batch_size * length, dtype=torch.bool),
             "temperature": torch.zeros(batch_size),
             "cfg_value": torch.zeros(batch_size),
+            "z_noise": torch.zeros(batch_size, self.feat_dim, self.patch_size, dtype=self.dtype),
         }
 
     def make_dummy_outputs(self, batch_size: int) -> dict[str, torch.Tensor]:
@@ -111,7 +113,7 @@ class VoxCPMRunner(BaseModelRunner):
         feats = []
         feat_masks = []
         temperatures = []
-        cfg_values = []
+        cfg_values = []        
         for seq in seqs:
             payload: VoxCPMPayload = seq.custom_payload
             assert payload.text_tokens.shape[0] == payload.feats.shape[0]
@@ -122,7 +124,7 @@ class VoxCPMRunner(BaseModelRunner):
             feat_masks.append(payload.feat_masks)
 
             temperatures.append(payload.temperature)
-            cfg_values.append(payload.cfg_value)
+            cfg_values.append(payload.cfg_value)            
 
         inputs["text_tokens"] = torch.from_numpy(np.concatenate(text_tokens, axis=0)).cuda(non_blocking=True)
         inputs["feat"] = torch.from_numpy(np.concatenate(feats, axis=0)).cuda(non_blocking=True).to(self.dtype)
@@ -133,9 +135,21 @@ class VoxCPMRunner(BaseModelRunner):
         inputs["cfg_value"] = (
             torch.tensor(cfg_values, dtype=torch.float32, pin_memory=True).cuda(non_blocking=True).to(self.dtype)
         )
-
+        
+        # Generate z_noise for each sequence based on the seed value in the payload
+        bsz = len(seqs)
+        z_noise = torch.empty((bsz, self.feat_dim, self.patch_size), dtype=self.dtype, device="cuda")
+        for i, seq in enumerate(seqs):
+            seed_val = seq.custom_payload.seed
+            if seed_val is not None and seed_val >= 0:
+                generator = torch.Generator(device="cuda").manual_seed(int(seed_val))
+            else:
+                generator = None        
+            z_noise[i] = torch.randn((self.feat_dim, self.patch_size), generator=generator, dtype=self.dtype, device="cuda")
+        
+        inputs["z_noise"] = z_noise
+        
         outputs = self.run_model(inputs, is_prefill)
-
         latents = outputs["latents"]
 
         pad_lengths = []

--- a/nanovllm_voxcpm/models/voxcpm/server.py
+++ b/nanovllm_voxcpm/models/voxcpm/server.py
@@ -125,7 +125,13 @@ class VoxCPMServerImpl:
         temperature: float = 1.0,
         cfg_value: float = 1.0,
         lora_name: str | None = None,
+        seed: int | None = None,
     ) -> None:
+        if seed is not None:
+            import torch
+            torch.manual_seed(seed)
+            torch.cuda.manual_seed_all(seed)
+            
         if prompt_latents is None:
             if len(prompt_text) > 0:
                 raise ValueError("Prompt text is not allowed when prompt latents are not provided")
@@ -497,6 +503,7 @@ class AsyncVoxCPMServer:
         temperature: float = 1.0,
         cfg_value: float = 2.0,
         lora_name: str | None = None,
+        seed: int | None = None, 
     ) -> AsyncGenerator[Waveform, None]:
         seq_id = gen_uuid()
         self.stream_table[seq_id] = asyncio.Queue()
@@ -513,6 +520,7 @@ class AsyncVoxCPMServer:
                 temperature,
                 cfg_value,
                 lora_name,
+                seed,
             )
 
             while True:
@@ -642,6 +650,7 @@ class AsyncVoxCPMServerPool:
         temperature: float = 1.0,
         cfg_value: float = 2.0,
         lora_name: str | None = None,
+        seed: int | None = None,
     ):
         """Generate audio conditioned on text and optional prompt.
 
@@ -664,7 +673,7 @@ class AsyncVoxCPMServerPool:
             max_generate_length: Maximum number of generated steps.
             temperature: Sampling temperature.
             cfg_value: Classifier-free guidance scale.
-
+            seed: Optional random seed for reproducibility. If set, this will fix the
         Yields:
             Waveform chunks as ``np.ndarray`` of dtype ``float32``.
 
@@ -702,6 +711,7 @@ class AsyncVoxCPMServerPool:
                 temperature,
                 cfg_value,
                 lora_name,
+                seed
             ):
                 yield data
         finally:
@@ -784,6 +794,7 @@ class SyncVoxCPMServerPool:
         temperature: float = 1.0,
         cfg_value: float = 2.0,
         lora_name: str | None = None,
+        seed: int | None = None,
     ):
         """Generate audio conditioned on text and optional prompt.
 
@@ -800,7 +811,8 @@ class SyncVoxCPMServerPool:
             max_generate_length: Maximum number of generated steps.
             temperature: Sampling temperature.
             cfg_value: Classifier-free guidance scale.
-
+            seed: Optional random seed for reproducibility. If set, this will fix the
+                generation output for identical inputs.
         Yields:
             Waveform chunks as ``np.ndarray`` of dtype ``float32``.
 
@@ -817,6 +829,7 @@ class SyncVoxCPMServerPool:
             temperature,
             cfg_value,
             lora_name,
+            seed
         )
         try:
             while True:

--- a/nanovllm_voxcpm/models/voxcpm/server.py
+++ b/nanovllm_voxcpm/models/voxcpm/server.py
@@ -127,7 +127,7 @@ class VoxCPMServerImpl:
         lora_name: str | None = None,
         seed: int | None = None,
     ) -> None:
-                    
+
         if prompt_latents is None:
             if len(prompt_text) > 0:
                 raise ValueError("Prompt text is not allowed when prompt latents are not provided")
@@ -501,7 +501,7 @@ class AsyncVoxCPMServer:
         temperature: float = 1.0,
         cfg_value: float = 2.0,
         lora_name: str | None = None,
-        seed: int | None = None, 
+        seed: int | None = None,
     ) -> AsyncGenerator[Waveform, None]:
         seq_id = gen_uuid()
         self.stream_table[seq_id] = asyncio.Queue()
@@ -702,14 +702,7 @@ class AsyncVoxCPMServerPool:
 
         try:
             async for data in server.generate(
-                target_text,
-                prompt_latents,
-                prompt_text,
-                max_generate_length,
-                temperature,
-                cfg_value,
-                lora_name,
-                seed
+                target_text, prompt_latents, prompt_text, max_generate_length, temperature, cfg_value, lora_name, seed
             ):
                 yield data
         finally:
@@ -827,7 +820,7 @@ class SyncVoxCPMServerPool:
             temperature,
             cfg_value,
             lora_name,
-            seed
+            seed,
         )
         try:
             while True:

--- a/nanovllm_voxcpm/models/voxcpm/server.py
+++ b/nanovllm_voxcpm/models/voxcpm/server.py
@@ -127,11 +127,7 @@ class VoxCPMServerImpl:
         lora_name: str | None = None,
         seed: int | None = None,
     ) -> None:
-        if seed is not None:
-            import torch
-            torch.manual_seed(seed)
-            torch.cuda.manual_seed_all(seed)
-            
+                    
         if prompt_latents is None:
             if len(prompt_text) > 0:
                 raise ValueError("Prompt text is not allowed when prompt latents are not provided")
@@ -143,6 +139,7 @@ class VoxCPMServerImpl:
                 temperature=temperature,
                 cfg_value=cfg_value,
                 lora_name=lora_name,
+                seed=seed,
             )
             return
 
@@ -164,6 +161,7 @@ class VoxCPMServerImpl:
             temperature=temperature,
             cfg_value=cfg_value,
             lora_name=lora_name,
+            seed=seed,
         )
 
     def register_lora(self, name: str, path: str) -> RegisterLoRAResponse:

--- a/nanovllm_voxcpm/models/voxcpm2/engine.py
+++ b/nanovllm_voxcpm/models/voxcpm2/engine.py
@@ -23,6 +23,7 @@ class VoxCPM2SeqPayload:
     cfg_value: float
     decode_pad: np.ndarray | None = None
     max_generate_length: int | None = None
+    seed: int | None = None
 
 
 class VoxCPM2Engine(LLMEngineBase):
@@ -61,6 +62,7 @@ class VoxCPM2Engine(LLMEngineBase):
                     temperature=seq.custom_payload.temperature,
                     cfg_value=seq.custom_payload.cfg_value,
                     padding_decode=seq.custom_payload.decode_pad,
+                    seed=seq.custom_payload.seed,
                 ),
                 adapter_id=seq.adapter_id,
             )
@@ -77,6 +79,7 @@ class VoxCPM2Engine(LLMEngineBase):
                 temperature=seq.custom_payload.temperature,
                 cfg_value=seq.custom_payload.cfg_value,
                 padding_decode=seq.custom_payload.decode_pad,
+                seed=seq.custom_payload.seed,
             ),
             adapter_id=seq.adapter_id,
         )
@@ -119,6 +122,7 @@ class VoxCPM2Engine(LLMEngineBase):
         temperature: float = 1.0,
         cfg_value: float = 1.0,
         lora_name: str | None = None,
+        seed: int | None = None,
     ):
         if max_generate_length < 1:
             raise ValueError(f"max_generate_length must be >= 1, got {max_generate_length}")
@@ -189,6 +193,7 @@ class VoxCPM2Engine(LLMEngineBase):
                 cfg_value=cfg_value,
                 max_generate_length=max_generate_length,
                 generated_waveforms=[],
+                seed=seed,
             ),
             lora_name=lora_name,
             adapter_id=adapter_id,

--- a/nanovllm_voxcpm/models/voxcpm2/engine.py
+++ b/nanovllm_voxcpm/models/voxcpm2/engine.py
@@ -24,6 +24,7 @@ class VoxCPM2SeqPayload:
     decode_pad: np.ndarray | None = None
     max_generate_length: int | None = None
     seed: int | None = None
+    seed_step: int = 0
 
 
 class VoxCPM2Engine(LLMEngineBase):
@@ -63,6 +64,7 @@ class VoxCPM2Engine(LLMEngineBase):
                     cfg_value=seq.custom_payload.cfg_value,
                     padding_decode=seq.custom_payload.decode_pad,
                     seed=seq.custom_payload.seed,
+                    seed_step=seq.custom_payload.seed_step,
                 ),
                 adapter_id=seq.adapter_id,
             )
@@ -80,6 +82,7 @@ class VoxCPM2Engine(LLMEngineBase):
                 cfg_value=seq.custom_payload.cfg_value,
                 padding_decode=seq.custom_payload.decode_pad,
                 seed=seq.custom_payload.seed,
+                seed_step=seq.custom_payload.seed_step,
             ),
             adapter_id=seq.adapter_id,
         )
@@ -93,6 +96,8 @@ class VoxCPM2Engine(LLMEngineBase):
         seq.custom_payload.feats.append(latents[None])
         seq.custom_payload.text_tokens.append(0)
         seq.custom_payload.feat_masks.append(True)
+        if seq.custom_payload.seed is not None and seq.custom_payload.seed >= 0:
+            seq.custom_payload.seed_step += 1
         seq.custom_payload.generated_waveforms.append(waveforms)
 
         latents = latents.reshape(-1, self.feat_dim)
@@ -194,6 +199,7 @@ class VoxCPM2Engine(LLMEngineBase):
                 max_generate_length=max_generate_length,
                 generated_waveforms=[],
                 seed=seed,
+                seed_step=0,
             ),
             lora_name=lora_name,
             adapter_id=adapter_id,

--- a/nanovllm_voxcpm/models/voxcpm2/model.py
+++ b/nanovllm_voxcpm/models/voxcpm2/model.py
@@ -431,9 +431,14 @@ class UnifiedCFM(nn.Module):
         cond: torch.Tensor,
         temperature: torch.Tensor,
         cfg_value: torch.Tensor,
+        z_noise: torch.Tensor | None = None,
     ):
         bsz = mu.shape[0]
-        z = torch.randn((bsz, self.in_channels, self.patch_size), device=mu.device, dtype=mu.dtype)
+        if z_noise is not None:            
+            z = z_noise
+        else:            
+            z = torch.randn((bsz, self.in_channels, self.patch_size), device=mu.device, dtype=mu.dtype)
+        
         z = z * temperature[:, None, None]
         t_span = torch.linspace(1, 0, self.inference_timesteps + 1, device=mu.device, dtype=mu.dtype)
         t_span = t_span + (torch.cos(torch.pi / 2 * t_span) - 1 + t_span)
@@ -565,7 +570,7 @@ class VoxCPM2Model(nn.Module):
             inference_timesteps=inference_timesteps,
             cfm_params=config.dit_config.cfm_config,
             estimator=VoxCPM2LocDiT(decoder_config, in_channels=config.feat_dim, lora_config=lora_config),
-            mean_mode=config.dit_mean_mode,
+            mean_mode=config.dit_mean_mode,            
         )
 
         self.fsq_layer = ScalarQuantizationLayer(
@@ -636,6 +641,7 @@ class VoxCPM2Model(nn.Module):
         feat_mask: torch.Tensor,
         temperature: torch.Tensor,
         cfg_value: torch.Tensor,
+        z_noise: torch.Tensor | None = None, 
     ):
         feat_embeds = self.enc_to_lm_proj(self.feat_encoder(feat))
         feat_embeds = torch.masked_fill(feat_embeds, feat_mask.unsqueeze(-1).logical_not(), 0)
@@ -669,6 +675,7 @@ class VoxCPM2Model(nn.Module):
             cond=prefix_feat_cond.transpose(1, 2).contiguous(),
             temperature=temperature,
             cfg_value=cfg_value,
+            z_noise=z_noise,
         ).transpose(1, 2)
         stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(dim=-1)
         return {"latents": pred_feat, "stop_flag": stop_flag}

--- a/nanovllm_voxcpm/models/voxcpm2/model.py
+++ b/nanovllm_voxcpm/models/voxcpm2/model.py
@@ -434,11 +434,11 @@ class UnifiedCFM(nn.Module):
         z_noise: torch.Tensor | None = None,
     ):
         bsz = mu.shape[0]
-        if z_noise is not None:            
+        if z_noise is not None:
             z = z_noise
-        else:            
+        else:
             z = torch.randn((bsz, self.in_channels, self.patch_size), device=mu.device, dtype=mu.dtype)
-        
+
         z = z * temperature[:, None, None]
         t_span = torch.linspace(1, 0, self.inference_timesteps + 1, device=mu.device, dtype=mu.dtype)
         t_span = t_span + (torch.cos(torch.pi / 2 * t_span) - 1 + t_span)
@@ -570,7 +570,7 @@ class VoxCPM2Model(nn.Module):
             inference_timesteps=inference_timesteps,
             cfm_params=config.dit_config.cfm_config,
             estimator=VoxCPM2LocDiT(decoder_config, in_channels=config.feat_dim, lora_config=lora_config),
-            mean_mode=config.dit_mean_mode,            
+            mean_mode=config.dit_mean_mode,
         )
 
         self.fsq_layer = ScalarQuantizationLayer(
@@ -641,7 +641,7 @@ class VoxCPM2Model(nn.Module):
         feat_mask: torch.Tensor,
         temperature: torch.Tensor,
         cfg_value: torch.Tensor,
-        z_noise: torch.Tensor | None = None, 
+        z_noise: torch.Tensor | None = None,
     ):
         feat_embeds = self.enc_to_lm_proj(self.feat_encoder(feat))
         feat_embeds = torch.masked_fill(feat_embeds, feat_mask.unsqueeze(-1).logical_not(), 0)

--- a/nanovllm_voxcpm/models/voxcpm2/runner.py
+++ b/nanovllm_voxcpm/models/voxcpm2/runner.py
@@ -21,7 +21,7 @@ class VoxCPM2Payload:
     temperature: float = 1.0
     cfg_value: float = 1.0
     padding_decode: np.ndarray | None = None
-
+    seed: int | None = None
 
 class VoxCPM2Runner(BaseModelRunner):
     model: VoxCPM2Model
@@ -62,6 +62,7 @@ class VoxCPM2Runner(BaseModelRunner):
             "feat_mask": torch.zeros(batch_size * length, dtype=torch.bool),
             "temperature": torch.zeros(batch_size),
             "cfg_value": torch.zeros(batch_size),
+            "z_noise": torch.zeros(batch_size, self.feat_dim, self.patch_size, dtype=self.dtype),
         }
 
     def make_dummy_outputs(self, batch_size: int) -> dict[str, torch.Tensor]:
@@ -90,7 +91,7 @@ class VoxCPM2Runner(BaseModelRunner):
         feats = []
         feat_masks = []
         temperatures = []
-        cfg_values = []
+        cfg_values = []        
         for seq in seqs:
             payload = seq.custom_payload
             assert payload.text_tokens.shape[0] == payload.feats.shape[0]
@@ -100,7 +101,7 @@ class VoxCPM2Runner(BaseModelRunner):
             feat_masks.append(payload.feat_masks)
             temperatures.append(payload.temperature)
             cfg_values.append(payload.cfg_value)
-
+            
         inputs["text_tokens"] = torch.from_numpy(np.concatenate(text_tokens, axis=0)).cuda(non_blocking=True)
         inputs["feat"] = torch.from_numpy(np.concatenate(feats, axis=0)).cuda(non_blocking=True).to(self.dtype)
         inputs["feat_mask"] = torch.from_numpy(np.concatenate(feat_masks, axis=0)).cuda(non_blocking=True)
@@ -110,14 +111,28 @@ class VoxCPM2Runner(BaseModelRunner):
         inputs["cfg_value"] = (
             torch.tensor(cfg_values, dtype=torch.float32, pin_memory=True).cuda(non_blocking=True).to(self.dtype)
         )
-
+        
+        # Generate z_noise for each sequence based on the seed value in the payload
+        bsz = len(seqs)
+        z_noise = torch.empty((bsz, self.feat_dim, self.patch_size), dtype=self.dtype, device="cuda")
+        for i, seq in enumerate(seqs):
+            seed_val = seq.custom_payload.seed
+            if seed_val is not None and seed_val >= 0:
+                generator = torch.Generator(device="cuda").manual_seed(int(seed_val))
+            else:
+                generator = None
+            z_noise[i] = torch.randn((self.feat_dim, self.patch_size), generator=generator, dtype=self.dtype, device="cuda")
+        
+        inputs["z_noise"] = z_noise
+        
         outputs = self.run_model(inputs, is_prefill)
         latents = outputs["latents"]
-
+        
         pad_lengths = [
             seq.custom_payload.padding_decode.shape[0] if seq.custom_payload.padding_decode is not None else 0
             for seq in seqs
         ]
+        
         max_pad_decode = max(pad_lengths) + self.patch_size
         vae_decoder_inputs = torch.zeros(len(seqs), max_pad_decode, self.feat_dim, dtype=torch.float32, device="cuda")
         for i, seq in enumerate(seqs):

--- a/nanovllm_voxcpm/models/voxcpm2/runner.py
+++ b/nanovllm_voxcpm/models/voxcpm2/runner.py
@@ -11,6 +11,7 @@ from nanovllm_voxcpm.layers.audio_vae_v2 import AudioVAEV2
 from nanovllm_voxcpm.models.voxcpm2.config import VoxCPM2Config
 from nanovllm_voxcpm.models.voxcpm2.model import VoxCPM2Model
 from nanovllm_voxcpm.utils.loader import load_model
+from nanovllm_voxcpm.utils.seed import derive_step_seed
 
 
 @dataclass
@@ -22,6 +23,8 @@ class VoxCPM2Payload:
     cfg_value: float = 1.0
     padding_decode: np.ndarray | None = None
     seed: int | None = None
+    seed_step: int = 0
+
 
 class VoxCPM2Runner(BaseModelRunner):
     model: VoxCPM2Model
@@ -91,7 +94,7 @@ class VoxCPM2Runner(BaseModelRunner):
         feats = []
         feat_masks = []
         temperatures = []
-        cfg_values = []        
+        cfg_values = []
         for seq in seqs:
             payload = seq.custom_payload
             assert payload.text_tokens.shape[0] == payload.feats.shape[0]
@@ -101,7 +104,7 @@ class VoxCPM2Runner(BaseModelRunner):
             feat_masks.append(payload.feat_masks)
             temperatures.append(payload.temperature)
             cfg_values.append(payload.cfg_value)
-            
+
         inputs["text_tokens"] = torch.from_numpy(np.concatenate(text_tokens, axis=0)).cuda(non_blocking=True)
         inputs["feat"] = torch.from_numpy(np.concatenate(feats, axis=0)).cuda(non_blocking=True).to(self.dtype)
         inputs["feat_mask"] = torch.from_numpy(np.concatenate(feat_masks, axis=0)).cuda(non_blocking=True)
@@ -111,28 +114,34 @@ class VoxCPM2Runner(BaseModelRunner):
         inputs["cfg_value"] = (
             torch.tensor(cfg_values, dtype=torch.float32, pin_memory=True).cuda(non_blocking=True).to(self.dtype)
         )
-        
-        # Generate z_noise for each sequence based on the seed value in the payload
+
         bsz = len(seqs)
-        z_noise = torch.empty((bsz, self.feat_dim, self.patch_size), dtype=self.dtype, device="cuda")
-        for i, seq in enumerate(seqs):
-            seed_val = seq.custom_payload.seed
-            if seed_val is not None and seed_val >= 0:
-                generator = torch.Generator(device="cuda").manual_seed(int(seed_val))
-            else:
-                generator = None
-            z_noise[i] = torch.randn((self.feat_dim, self.patch_size), generator=generator, dtype=self.dtype, device="cuda")
-        
+        seeded_rows = [
+            (i, int(seq.custom_payload.seed), seq.custom_payload.seed_step)
+            for i, seq in enumerate(seqs)
+            if seq.custom_payload.seed is not None and seq.custom_payload.seed >= 0
+        ]
+        if len(seeded_rows) == bsz:
+            z_noise = torch.empty((bsz, self.feat_dim, self.patch_size), dtype=self.dtype, device="cuda")
+        else:
+            z_noise = torch.randn((bsz, self.feat_dim, self.patch_size), dtype=self.dtype, device="cuda")
+
+        for i, seed_val, seed_step in seeded_rows:
+            generator = torch.Generator(device="cuda").manual_seed(derive_step_seed(seed_val, seed_step))
+            z_noise[i] = torch.randn(
+                (self.feat_dim, self.patch_size), generator=generator, dtype=self.dtype, device="cuda"
+            )
+
         inputs["z_noise"] = z_noise
-        
+
         outputs = self.run_model(inputs, is_prefill)
         latents = outputs["latents"]
-        
+
         pad_lengths = [
             seq.custom_payload.padding_decode.shape[0] if seq.custom_payload.padding_decode is not None else 0
             for seq in seqs
         ]
-        
+
         max_pad_decode = max(pad_lengths) + self.patch_size
         vae_decoder_inputs = torch.zeros(len(seqs), max_pad_decode, self.feat_dim, dtype=torch.float32, device="cuda")
         for i, seq in enumerate(seqs):

--- a/nanovllm_voxcpm/models/voxcpm2/server.py
+++ b/nanovllm_voxcpm/models/voxcpm2/server.py
@@ -126,7 +126,7 @@ class VoxCPM2ServerImpl:
         lora_name: str | None = None,
         seed: int | None = None,
     ) -> None:
-                    
+
         if prompt_latents is None:
             if len(prompt_text) > 0:
                 raise ValueError("Prompt text is not allowed when prompt latents are not provided")
@@ -437,7 +437,7 @@ class AsyncVoxCPM2Server:
         cfg_value: float = 2.0,
         ref_audio_latents: bytes | None = None,
         lora_name: str | None = None,
-        seed: int | None = None
+        seed: int | None = None,
     ) -> AsyncGenerator[Waveform, None]:
         seq_id = gen_uuid()
         self.stream_table[seq_id] = asyncio.Queue()

--- a/nanovllm_voxcpm/models/voxcpm2/server.py
+++ b/nanovllm_voxcpm/models/voxcpm2/server.py
@@ -126,11 +126,7 @@ class VoxCPM2ServerImpl:
         lora_name: str | None = None,
         seed: int | None = None,
     ) -> None:
-        if seed is not None:
-            import torch
-            torch.manual_seed(seed)
-            torch.cuda.manual_seed_all(seed)
-            
+                    
         if prompt_latents is None:
             if len(prompt_text) > 0:
                 raise ValueError("Prompt text is not allowed when prompt latents are not provided")
@@ -147,6 +143,7 @@ class VoxCPM2ServerImpl:
                 temperature=temperature,
                 cfg_value=cfg_value,
                 lora_name=lora_name,
+                seed=seed,
             )
             return
 
@@ -168,6 +165,7 @@ class VoxCPM2ServerImpl:
             temperature=temperature,
             cfg_value=cfg_value,
             lora_name=lora_name,
+            seed=seed,
         )
 
     def register_lora(self, name: str, path: str) -> RegisterLoRAResponse:

--- a/nanovllm_voxcpm/models/voxcpm2/server.py
+++ b/nanovllm_voxcpm/models/voxcpm2/server.py
@@ -124,7 +124,13 @@ class VoxCPM2ServerImpl:
         cfg_value: float = 1.0,
         ref_audio_latents: bytes | None = None,
         lora_name: str | None = None,
+        seed: int | None = None,
     ) -> None:
+        if seed is not None:
+            import torch
+            torch.manual_seed(seed)
+            torch.cuda.manual_seed_all(seed)
+            
         if prompt_latents is None:
             if len(prompt_text) > 0:
                 raise ValueError("Prompt text is not allowed when prompt latents are not provided")
@@ -433,6 +439,7 @@ class AsyncVoxCPM2Server:
         cfg_value: float = 2.0,
         ref_audio_latents: bytes | None = None,
         lora_name: str | None = None,
+        seed: int | None = None
     ) -> AsyncGenerator[Waveform, None]:
         seq_id = gen_uuid()
         self.stream_table[seq_id] = asyncio.Queue()
@@ -449,6 +456,7 @@ class AsyncVoxCPM2Server:
                 cfg_value,
                 ref_audio_latents,
                 lora_name,
+                seed,
             )
             while True:
                 data = await self.stream_table[seq_id].get()
@@ -567,6 +575,7 @@ class AsyncVoxCPM2ServerPool:
         cfg_value: float = 2.0,
         ref_audio_latents: bytes | None = None,
         lora_name: str | None = None,
+        seed: int | None = None,
     ):
         if prompt_id is not None:
             if prompt_id not in self._prompt_pool:
@@ -595,6 +604,7 @@ class AsyncVoxCPM2ServerPool:
                 cfg_value,
                 ref_audio_latents,
                 lora_name,
+                seed,
             ):
                 yield data
         finally:
@@ -678,6 +688,7 @@ class SyncVoxCPM2ServerPool:
         cfg_value: float = 2.0,
         ref_audio_latents: bytes | None = None,
         lora_name: str | None = None,
+        seed: int | None = None,
     ):
         assert self.loop is not None
         async_gen = self.server_pool.generate(
@@ -690,6 +701,7 @@ class SyncVoxCPM2ServerPool:
             cfg_value,
             ref_audio_latents,
             lora_name,
+            seed,
         )
         try:
             while True:

--- a/nanovllm_voxcpm/utils/seed.py
+++ b/nanovllm_voxcpm/utils/seed.py
@@ -1,0 +1,14 @@
+_UINT64_MASK = (1 << 64) - 1
+_SPLITMIX64_INCREMENT = 0x9E3779B97F4A7C15
+_SPLITMIX64_MUL1 = 0xBF58476D1CE4E5B9
+_SPLITMIX64_MUL2 = 0x94D049BB133111EB
+
+
+def derive_step_seed(seed: int, seed_step: int) -> int:
+    """Derive a deterministic per-step seed from a request seed."""
+
+    value = (int(seed) & _UINT64_MASK) ^ ((int(seed_step) + _SPLITMIX64_INCREMENT) & _UINT64_MASK)
+    value = (value + _SPLITMIX64_INCREMENT) & _UINT64_MASK
+    value = ((value ^ (value >> 30)) * _SPLITMIX64_MUL1) & _UINT64_MASK
+    value = ((value ^ (value >> 27)) * _SPLITMIX64_MUL2) & _UINT64_MASK
+    return (value ^ (value >> 31)) & _UINT64_MASK

--- a/tests/unit/test_seed_utils.py
+++ b/tests/unit/test_seed_utils.py
@@ -1,0 +1,10 @@
+from nanovllm_voxcpm.utils.seed import derive_step_seed
+
+
+def test_derive_step_seed_is_stable_for_same_request_step():
+    assert derive_step_seed(123, 4) == derive_step_seed(123, 4)
+
+
+def test_derive_step_seed_advances_for_different_steps():
+    seeds = {derive_step_seed(123, step) for step in range(8)}
+    assert len(seeds) == 8

--- a/tests/unit/test_voxcpm2_chunk_sizes.py
+++ b/tests/unit/test_voxcpm2_chunk_sizes.py
@@ -74,6 +74,8 @@ def test_voxcpm2_runner_slices_decoded_waveform_with_decoder_chunk_size(monkeypa
 
     original_zeros = torch.zeros
     original_tensor = torch.tensor
+    original_randn = torch.randn
+    randn_shapes = []
 
     def _cpu_zeros(*args, **kwargs):
         kwargs.pop("device", None)
@@ -83,9 +85,15 @@ def test_voxcpm2_runner_slices_decoded_waveform_with_decoder_chunk_size(monkeypa
         kwargs.pop("pin_memory", None)
         return original_tensor(*args, **kwargs)
 
+    def _cpu_randn(*args, **kwargs):
+        kwargs.pop("device", None)
+        randn_shapes.append(args[0])
+        return original_randn(*args, **kwargs)
+
     monkeypatch.setattr(torch.Tensor, "cuda", lambda self, non_blocking=True: self, raising=False)
     monkeypatch.setattr(torch, "zeros", _cpu_zeros)
     monkeypatch.setattr(torch, "tensor", _cpu_tensor)
+    monkeypatch.setattr(torch, "randn", _cpu_randn)
 
     runner = VoxCPM2Runner.__new__(VoxCPM2Runner)
     runner.patch_size = 4
@@ -133,4 +141,5 @@ def test_voxcpm2_runner_slices_decoded_waveform_with_decoder_chunk_size(monkeypa
 
     outputs = runner.run([seq], is_prefill=False)
 
+    assert randn_shapes == [(1, runner.feat_dim, runner.patch_size)]
     assert outputs[0]["waveforms"].tolist() == list(range(6, 18))

--- a/tests/unit/test_voxcpm2_engine_max_model_len.py
+++ b/tests/unit/test_voxcpm2_engine_max_model_len.py
@@ -54,3 +54,47 @@ def test_add_request_resolves_lora_name_into_adapter_id():
     e.add_request(seq_id="s", target_text="x", max_generate_length=6, lora_name="demo")
     assert e._captured_seq.lora_name == "demo"
     assert e._captured_seq.adapter_id == 9
+
+
+def test_postprocess_advances_seed_step_after_generated_latent():
+    import numpy as np
+
+    from nanovllm_voxcpm.models.voxcpm2.engine import VoxCPM2Engine, VoxCPM2SeqPayload
+
+    engine = VoxCPM2Engine.__new__(VoxCPM2Engine)
+    engine.feat_dim = 2
+    engine.patch_size = 4
+    engine.n_decode_pad_frames = 4
+
+    class _Seq:
+        stoped = False
+
+        def __init__(self):
+            self.tokens = []
+            self.custom_payload = VoxCPM2SeqPayload(
+                feats=[],
+                text_tokens=[],
+                feat_masks=[],
+                generated_waveforms=[],
+                temperature=1.0,
+                cfg_value=1.0,
+                max_generate_length=10,
+                seed=123,
+                seed_step=2,
+            )
+
+        def append_token(self, token):
+            self.tokens.append(token)
+
+    seq = _Seq()
+    engine.postprocess_seq(
+        seq,
+        {
+            "latents": np.zeros((engine.patch_size, engine.feat_dim), dtype=np.float32),
+            "waveforms": np.zeros(8, dtype=np.float32),
+            "stop_flag": 0,
+        },
+        is_prefill=False,
+    )
+
+    assert seq.custom_payload.seed_step == 3

--- a/tests/unit/test_voxcpm2_serverpool_lora_api.py
+++ b/tests/unit/test_voxcpm2_serverpool_lora_api.py
@@ -27,8 +27,9 @@ class _FakeServer:
         cfg_value=2.0,
         ref_audio_latents=None,
         lora_name=None,
+        seed=42
     ):
-        self.generate_calls.append({"lora_name": lora_name, "ref_audio_latents": ref_audio_latents})
+        self.generate_calls.append({"lora_name": lora_name, "ref_audio_latents": ref_audio_latents, "cfg_value": cfg_value, "seed": seed})
         yield "chunk"
 
 

--- a/tests/unit/test_voxcpm2_serverpool_lora_api.py
+++ b/tests/unit/test_voxcpm2_serverpool_lora_api.py
@@ -27,9 +27,11 @@ class _FakeServer:
         cfg_value=2.0,
         ref_audio_latents=None,
         lora_name=None,
-        seed=42
+        seed=42,
     ):
-        self.generate_calls.append({"lora_name": lora_name, "ref_audio_latents": ref_audio_latents, "cfg_value": cfg_value, "seed": seed})
+        self.generate_calls.append(
+            {"lora_name": lora_name, "ref_audio_latents": ref_audio_latents, "cfg_value": cfg_value, "seed": seed}
+        )
         yield "chunk"
 
 

--- a/tests/unit/test_voxcpm_engine_max_model_len.py
+++ b/tests/unit/test_voxcpm_engine_max_model_len.py
@@ -61,3 +61,47 @@ def test_add_request_resolves_lora_name_into_adapter_id():
     e.add_request(seq_id="s", target_text="x", max_generate_length=6, lora_name="demo")
     assert e._captured_seq.lora_name == "demo"
     assert e._captured_seq.adapter_id == 7
+
+
+def test_postprocess_advances_seed_step_after_generated_latent():
+    import numpy as np
+
+    from nanovllm_voxcpm.models.voxcpm.engine import VoxCPMEngine, VoxCPMSeqPayload
+
+    engine = VoxCPMEngine.__new__(VoxCPMEngine)
+    engine.feat_dim = 2
+    engine.patch_size = 4
+    engine.n_decode_pad_frames = 4
+
+    class _Seq:
+        stoped = False
+
+        def __init__(self):
+            self.tokens = []
+            self.custom_payload = VoxCPMSeqPayload(
+                feats=[],
+                text_tokens=[],
+                feat_masks=[],
+                generated_waveforms=[],
+                temperature=1.0,
+                cfg_value=1.0,
+                max_generate_length=10,
+                seed=123,
+                seed_step=2,
+            )
+
+        def append_token(self, token):
+            self.tokens.append(token)
+
+    seq = _Seq()
+    engine.postprocess_seq(
+        seq,
+        {
+            "latents": np.zeros((engine.patch_size, engine.feat_dim), dtype=np.float32),
+            "waveforms": np.zeros(8, dtype=np.float32),
+            "stop_flag": 0,
+        },
+        is_prefill=False,
+    )
+
+    assert seq.custom_payload.seed_step == 3

--- a/tests/unit/test_voxcpm_serverpool_lora_api.py
+++ b/tests/unit/test_voxcpm_serverpool_lora_api.py
@@ -26,7 +26,7 @@ class _FakeServer:
         temperature=1.0,
         cfg_value=2.0,
         lora_name=None,
-        seed=42
+        seed=42,
     ):
         self.generate_calls.append(
             {
@@ -37,7 +37,7 @@ class _FakeServer:
                 "temperature": temperature,
                 "cfg_value": cfg_value,
                 "lora_name": lora_name,
-                "seed": seed
+                "seed": seed,
             }
         )
         yield "chunk"

--- a/tests/unit/test_voxcpm_serverpool_lora_api.py
+++ b/tests/unit/test_voxcpm_serverpool_lora_api.py
@@ -26,6 +26,7 @@ class _FakeServer:
         temperature=1.0,
         cfg_value=2.0,
         lora_name=None,
+        seed=42
     ):
         self.generate_calls.append(
             {
@@ -36,6 +37,7 @@ class _FakeServer:
                 "temperature": temperature,
                 "cfg_value": cfg_value,
                 "lora_name": lora_name,
+                "seed": seed
             }
         )
         yield "chunk"


### PR DESCRIPTION
### **PR Description:**

#### **Overview**
This Pull Request adds optional random seed (`seed`) support across the `nano-vllm-voxcpm` stack for both VoxCPM (v1/v1.5) and VoxCPM2.

The goal is reproducible speech generation when a caller explicitly provides a seed, while preserving the previous random behavior and fast batched path when no seed is provided.

---

#### **Key Changes**

##### **1. Request-Scoped Seed Propagation**
* Added `seed` support to the public generation paths for both VoxCPM and VoxCPM2.
* Propagated `seed` through the async/sync server pools, IPC server calls, engine `add_request()`, sequence payloads, and runner payloads.
* Avoided process-global RNG mutation in the request path. The implementation no longer relies on `torch.manual_seed(seed)` or `torch.cuda.manual_seed_all(seed)` in `add_request()`, so one request cannot overwrite the global RNG state used by another queued or batched request.

##### **2. Per-Step DiT Noise Without Repeating the Same Initial Noise**
* Added a request-local `seed_step` counter to the VoxCPM and VoxCPM2 sequence payloads.
* The runner derives a deterministic per-step seed via `derive_step_seed(seed, seed_step)` before generating seeded DiT `z_noise`.
* `postprocess_seq()` increments `seed_step` after each successfully generated latent, so the same request receives a deterministic RNG stream that advances across autoregressive decode steps.
* The same input and original seed still map to the same deterministic sequence of per-step noise values across runs, but each DiT call no longer restarts from identical initial noise.

##### **3. Seeded and Unseeded Noise Paths**
* Restored the common unseeded path to use batched noise generation:

```python
torch.randn((bsz, feat_dim, patch_size), ...)
```

* For mixed batches, the runner first generates the full batch normally and then overwrites only rows that belong to requests with a non-negative seed.
* For fully seeded batches, the runner allocates the batch tensor and fills each row from the request-local derived seed without consuming the process-global RNG stream.
* `z_noise` remains an explicit model input, so RNG generation happens outside the model forward/CUDA graph capture path.

##### **4. FastAPI REST Endpoint & Backward Compatibility**
* Added `seed: int | None = Field(None, ...)` to the deployment `GenerateRequest` schema.
* Updated `deployment/app/api/routes/generate.py` to inspect `server.generate` before forwarding optional compatibility-sensitive arguments.
* `seed` is only added to `generate_kwargs` when the client provides `req.seed`.
* If a client provides `seed` but the loaded server implementation does not accept a `seed` parameter, the route returns a clean `HTTPException(400)`.
* When no seed is supplied, the route does not pass `seed`, preserving the previous default/random behavior.

##### **5. Benchmarking Suite**
* Added `--seed` to:
  * `benchmark/bench_inference.py`
  * `benchmark/bench_open_loop_users.py`
  * `benchmark/bench_closed_loop_users.py`
* Propagated the seed through warmup and measured benchmark paths for both in-process and HTTP execution modes where applicable.

##### **6. Documentation**
* Documented benchmark `--seed` usage in `benchmark/README.md`.
* Documented the deployment API `seed` request field in `deployment/README.md`.

---

#### **Verification & Testing**

Targeted seed behavior tests:

```powershell
python -m pytest tests/unit/test_seed_utils.py tests/unit/test_voxcpm_engine_max_model_len.py::test_postprocess_advances_seed_step_after_generated_latent tests/unit/test_voxcpm2_engine_max_model_len.py::test_postprocess_advances_seed_step_after_generated_latent tests/unit/test_voxcpm2_chunk_sizes.py::test_voxcpm2_runner_slices_decoded_waveform_with_decoder_chunk_size -q
```

Focused regression set:

```powershell
python -m pytest tests/unit/test_seed_utils.py tests/unit/test_voxcpm_engine_max_model_len.py tests/unit/test_voxcpm2_engine_max_model_len.py tests/unit/test_voxcpm2_chunk_sizes.py -q
```

Result:

```text
18 passed
```

Syntax validation:

```powershell
python -m compileall nanovllm_voxcpm/utils/seed.py nanovllm_voxcpm/models/voxcpm/engine.py nanovllm_voxcpm/models/voxcpm/runner.py nanovllm_voxcpm/models/voxcpm2/engine.py nanovllm_voxcpm/models/voxcpm2/runner.py tests/unit/test_seed_utils.py tests/unit/test_voxcpm_engine_max_model_len.py tests/unit/test_voxcpm2_engine_max_model_len.py tests/unit/test_voxcpm2_chunk_sizes.py
```

Relevant commits:

```text
039d262 feat: add seed support for reproducible generation in both VoxCPM and VoxCPM2
f6300b7 refactor: secure per-request seeding under concurrency and fix API backward compatibility
461c351 Fix per-step seeded DiT noise
```
