### PR TITLE
fix: avoid AttributeError on LoRA + enforce_eager in run_model (#71)

### DIFF
--- a/nanovllm_voxcpm/engine/model_runner.py
+++ b/nanovllm_voxcpm/engine/model_runner.py
@@ -874,7 +874,7 @@ class BaseModelRunner:
         has_active_lora = any(
             not context.no_lora_flag and context.token_to_slot is not None for context in lora_contexts.values()
         )
-        has_lora_graph = has_active_lora and bool(self.graphs.get("lora"))
+        has_lora_graph = has_active_lora and bool(getattr(self, "graphs", {}).get("lora"))
         try:
             if (
                 is_prefill

--- a/tests/unit/test_model_runner_enforce_eager_lora.py
+++ b/tests/unit/test_model_runner_enforce_eager_lora.py
@@ -1,0 +1,50 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+def test_run_model_enforce_eager_with_active_lora_does_not_require_graphs():
+    """Regression test for issue #71.
+
+    When ``enforce_eager=True``, ``capture_cudagraph()`` is never called and the
+    runner never gains a ``graphs`` attribute. ``run_model`` must still be able
+    to serve requests with an active LoRA context by falling back to the eager
+    ``self.model(...)`` path, instead of crashing with::
+
+        AttributeError: 'VoxCPM2Runner' object has no attribute 'graphs'
+    """
+    import nanovllm_voxcpm.engine.model_runner as model_runner
+    from nanovllm_voxcpm.utils.context import (
+        LM_LORA_DOMAIN,
+        reset_all_contexts,
+        set_context,
+        set_lora_context_from_token_to_slot,
+    )
+
+    runner = object.__new__(model_runner.BaseModelRunner)
+    runner.enforce_eager = True
+    # Intentionally do NOT set ``runner.graphs`` — this mirrors the eager-mode
+    # runtime state, where ``capture_cudagraph()`` was skipped.
+    assert not hasattr(runner, "graphs")
+
+    captured: dict[str, object] = {}
+
+    def _fake_model(**inputs):
+        captured["called"] = True
+        captured["inputs"] = inputs
+        return {"latents": torch.zeros(1), "stop_flag": torch.zeros(1, dtype=torch.int64)}
+
+    runner.model = _fake_model
+
+    inputs = {"positions": torch.zeros(1, dtype=torch.int64)}
+
+    set_context(False, slot_mapping=torch.zeros(1, dtype=torch.int32))
+    # Active LoRA context: one decode token mapped to slot 0.
+    set_lora_context_from_token_to_slot(torch.tensor([0], dtype=torch.int32), domain=LM_LORA_DOMAIN)
+    try:
+        output = runner.run_model(inputs, is_prefill=False)
+    finally:
+        reset_all_contexts()
+
+    assert captured.get("called") is True
+    assert "latents" in output and "stop_flag" in output


### PR DESCRIPTION
## Summary

Fixes #71.

When `enforce_eager=True`, `BaseModelRunner.__init__` skips `capture_cudagraph()`, so the runner **never** gains a `graphs` attribute. However, `run_model` unconditionally read `self.graphs` **before** the `enforce_eager` short-circuit, so any request carrying an active LoRA context crashed with:

```
AttributeError: 'VoxCPM2Runner' object has no attribute 'graphs'
```

(See the traceback in #71, raised at `model_runner.py` `run_model`.)

## Root cause

- `self.graphs` is assigned only inside `capture_cudagraph()`.
- `capture_cudagraph()` runs only when `not self.enforce_eager`.
- `run_model` computed `has_lora_graph = has_active_lora and bool(self.graphs.get("lora"))` before reaching the `enforce_eager` branch that would otherwise route to the eager `self.model(...)` path.

So `enforce_eager=True` + active LoRA hit the missing attribute on every step.

## Fix

Guard the lookup with `getattr(self, "graphs", {})`. In eager mode this yields `has_lora_graph = False`, which makes the existing `(has_active_lora and not has_lora_graph)` condition route to the eager `self.model(**inputs)` path — exactly the intended behavior when CUDA graphs are disabled. Non-eager behavior is unchanged.

```diff
-        has_lora_graph = has_active_lora and bool(self.graphs.get("lora"))
+        has_lora_graph = has_active_lora and bool(getattr(self, "graphs", {}).get("lora"))
```

## Tests

Added `tests/unit/test_model_runner_enforce_eager_lora.py`, a CPU-only regression test that:

1. Builds a `BaseModelRunner` via `object.__new__` with `enforce_eager=True` and **no** `graphs` attribute (mirroring eager-mode runtime state).
2. Installs an active LoRA context for one decode token.
3. Asserts `run_model` falls back to the eager `self.model(...)` path instead of raising `AttributeError`.

The test fails on `main` with the exact `AttributeError` from #71 and passes with this fix.

```
uv run pytest tests/unit/test_model_runner_enforce_eager_lora.py -q   # passes
uv run pytest tests/unit -q -k "model_runner or lora or runner"        # 74 passed
uv run black --check ...                                                # clean
```