### PR TITLE
test: regression coverage for PR #67 perf optims + fix broken linear TP test

### DIFF
--- a/nanovllm_voxcpm/models/voxcpm2/model.py
+++ b/nanovllm_voxcpm/models/voxcpm2/model.py
@@ -460,20 +460,22 @@ class UnifiedCFM(nn.Module):
         t, dt = t_span[0], t_span[0] - t_span[1]
         zero_init_steps = max(1, int(len(t_span) * 0.04))
         bsz = x.size(0)
-        x_in    = torch.empty([2 * bsz, self.in_channels, x.size(2)], device=x.device, dtype=x.dtype)
-        mu_in   = torch.empty([2 * bsz, mu.size(1)],                   device=x.device, dtype=x.dtype)
-        t_in    = torch.empty([2 * bsz],                                device=x.device, dtype=x.dtype)
-        dt_in   = torch.empty([2 * bsz],                                device=x.device, dtype=x.dtype)
+        x_in = torch.empty([2 * bsz, self.in_channels, x.size(2)], device=x.device, dtype=x.dtype)
+        mu_in = torch.empty([2 * bsz, mu.size(1)], device=x.device, dtype=x.dtype)
+        t_in = torch.empty([2 * bsz], device=x.device, dtype=x.dtype)
+        dt_in = torch.empty([2 * bsz], device=x.device, dtype=x.dtype)
         cond_in = torch.empty([2 * bsz, self.in_channels, x.size(2)], device=x.device, dtype=x.dtype)
         for step in range(1, len(t_span)):
             if step <= zero_init_steps:
                 dphi_dt = 0.0
             else:
-                x_in[:bsz], x_in[bsz:]     = x, x
+                x_in[:bsz], x_in[bsz:] = x, x
                 mu_in[:bsz] = mu
                 mu_in[bsz:].zero_()
-                t_in[:bsz]  = t.unsqueeze(0);  t_in[bsz:]  = t.unsqueeze(0)
-                dt_in[:bsz] = dt.unsqueeze(0); dt_in[bsz:] = dt.unsqueeze(0)
+                t_in[:bsz] = t.unsqueeze(0)
+                t_in[bsz:] = t.unsqueeze(0)
+                dt_in[:bsz] = dt.unsqueeze(0)
+                dt_in[bsz:] = dt.unsqueeze(0)
                 if not self.mean_mode:
                     dt_in.zero_()
                 cond_in[:bsz], cond_in[bsz:] = cond, cond

--- a/tests/unit/test_layers_basic.py
+++ b/tests/unit/test_layers_basic.py
@@ -43,6 +43,46 @@ def test_rmsnorm_forward_and_residual_path():
     assert r2.shape == x.shape
 
 
+def _reference_rmsnorm(x: "torch.Tensor", weight: "torch.Tensor", eps: float) -> "torch.Tensor":
+    xf = x.float()
+    var = xf.pow(2).mean(dim=-1, keepdim=True)
+    normed = xf * torch.rsqrt(var + eps)
+    return (normed * weight.float()).to(x.dtype)
+
+
+def test_rmsnorm_forward_matches_reference():
+    from nanovllm_voxcpm.layers.layernorm import RMSNorm
+
+    eps = 1e-6
+    norm = RMSNorm(hidden_size=16, eps=eps)
+    with torch.no_grad():
+        norm.weight.copy_(torch.randn(16) * 0.1 + 1.0)
+
+    x = torch.randn(4, 16)
+    got = norm(x)
+    expected = _reference_rmsnorm(x, norm.weight, eps)
+    torch.testing.assert_close(got, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_rmsnorm_add_residual_is_exact_sum():
+    from nanovllm_voxcpm.layers.layernorm import RMSNorm
+
+    eps = 1e-6
+    norm = RMSNorm(hidden_size=16, eps=eps)
+    with torch.no_grad():
+        norm.weight.copy_(torch.randn(16) * 0.1 + 1.0)
+
+    x = torch.randn(4, 16)
+    residual = torch.randn(4, 16)
+
+    out, new_residual = norm(x, residual)
+
+    # add_rms_forward must return the pre-normalization sum bit-exactly (rtol=atol=0).
+    torch.testing.assert_close(new_residual, (x.float() + residual.float()).to(x.dtype), rtol=0, atol=0)
+    expected_out = _reference_rmsnorm(new_residual, norm.weight, eps)
+    torch.testing.assert_close(out, expected_out, rtol=1e-5, atol=1e-5)
+
+
 def test_silu_and_mul():
     from nanovllm_voxcpm.layers.activation import SiluAndMul
 

--- a/tests/unit/test_linear_layers.py
+++ b/tests/unit/test_linear_layers.py
@@ -6,16 +6,17 @@ torch = pytest.importorskip("torch")
 def test_column_parallel_linear_weight_loader_shards(monkeypatch):
     import nanovllm_voxcpm.layers.linear as linear
 
-    # Pretend we are in a 2-way tensor parallel group.
-    monkeypatch.setattr(linear.dist, "get_world_size", lambda: 2)
+    # Patch the tp helpers the layer actually calls (imported into linear's
+    # namespace), not torch.distributed's get_world_size/get_rank.
+    monkeypatch.setattr(linear, "get_tp_world_size", lambda: 2)
 
     full_weight = torch.arange(6 * 4, dtype=torch.float32).view(6, 4)
 
-    monkeypatch.setattr(linear.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(linear, "get_tp_rank", lambda: 0)
     m0 = linear.ColumnParallelLinear(input_size=4, output_size=6, bias=False)
     m0.weight_loader(m0.weight, full_weight)
 
-    monkeypatch.setattr(linear.dist, "get_rank", lambda: 1)
+    monkeypatch.setattr(linear, "get_tp_rank", lambda: 1)
     m1 = linear.ColumnParallelLinear(input_size=4, output_size=6, bias=False)
     m1.weight_loader(m1.weight, full_weight)
 

--- a/tests/unit/test_voxcpm2_euler_prealloc.py
+++ b/tests/unit/test_voxcpm2_euler_prealloc.py
@@ -1,0 +1,77 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+class _CapturingEstimator:
+    """Fake CFM estimator that records the inputs it receives each Euler step."""
+
+    def __init__(self, in_channels: int, patch: int):
+        self.in_channels = in_channels
+        self.patch = patch
+        self.calls: list[dict[str, torch.Tensor]] = []
+
+    def __call__(self, x_in, mu_in, t_in, cond_in, dt_in):
+        self.calls.append(
+            {
+                "x_in": x_in.clone(),
+                "mu_in": mu_in.clone(),
+                "t_in": t_in.clone(),
+                "cond_in": cond_in.clone(),
+                "dt_in": dt_in.clone(),
+            }
+        )
+        return torch.zeros(x_in.size(0), self.in_channels, self.patch, dtype=x_in.dtype)
+
+
+def _run_solver(mean_mode: bool):
+    from nanovllm_voxcpm.models.voxcpm2.model import UnifiedCFM
+
+    bsz, in_channels, patch = 2, 4, 3
+    n_steps = 6
+
+    cfm = UnifiedCFM.__new__(UnifiedCFM)
+    cfm.in_channels = in_channels
+    cfm.mean_mode = mean_mode
+    cfm.estimator = _CapturingEstimator(in_channels, patch)
+
+    x = torch.randn(bsz, in_channels, patch)
+    mu = torch.randn(bsz, in_channels * patch)
+    cond = torch.randn(bsz, in_channels, patch)
+    cfg_value = torch.ones(bsz)
+    t_span = torch.linspace(1, 0, n_steps + 1)
+
+    cfm.solve_euler(x, t_span=t_span, mu=mu, cond=cond, cfg_value=cfg_value)
+    return cfm.estimator, bsz, mu, cond
+
+
+def test_euler_unconditioned_mu_half_is_zeroed():
+    estimator, bsz, mu, _cond = _run_solver(mean_mode=False)
+
+    assert estimator.calls, "estimator was never invoked"
+    for call in estimator.calls:
+        mu_in = call["mu_in"]
+        # Conditioned half carries mu; unconditioned half MUST be zero even though
+        # the buffer is pre-allocated once with torch.empty (uninitialized memory).
+        torch.testing.assert_close(mu_in[:bsz], mu, rtol=0, atol=0)
+        torch.testing.assert_close(mu_in[bsz:], torch.zeros_like(mu_in[bsz:]), rtol=0, atol=0)
+
+
+def test_euler_buffers_fully_overwritten_each_step():
+    estimator, bsz, _mu, cond = _run_solver(mean_mode=False)
+
+    for call in estimator.calls:
+        x_in, cond_in = call["x_in"], call["cond_in"]
+        # Both halves of x_in / cond_in are written every step, so no stale/garbage
+        # values leak from the reused empty buffers.
+        torch.testing.assert_close(x_in[:bsz], x_in[bsz:], rtol=0, atol=0)
+        torch.testing.assert_close(cond_in[:bsz], cond, rtol=0, atol=0)
+        torch.testing.assert_close(cond_in[bsz:], cond, rtol=0, atol=0)
+
+
+def test_euler_dt_zeroed_when_not_mean_mode():
+    estimator, _bsz, _mu, _cond = _run_solver(mean_mode=False)
+
+    for call in estimator.calls:
+        dt_in = call["dt_in"]
+        torch.testing.assert_close(dt_in, torch.zeros_like(dt_in), rtol=0, atol=0)


### PR DESCRIPTION
## Summary

Adds regression tests that lock the behavior of the three kernel-level
optimizations merged in #67, fixes a pre-existing broken test in
`test_linear_layers.py`, and black-formats a block from #67 that was failing
the CI lint gate.

All tests are CPU-only (no GPU deps) and follow the existing unit-test
conventions (`pytest.importorskip`, GPU shims, `TORCHDYNAMO_DISABLE`).

## Changes

### 1. RMSNorm numerical regression — `tests/unit/test_layers_basic.py`
The existing `test_rmsnorm_forward_and_residual_path` only checked shapes, so
the #67 rewrite to `F.rms_norm` had no numerical guard. Added:
- `test_rmsnorm_forward_matches_reference` — output matches the fp32 reference formula.
- `test_rmsnorm_add_residual_is_exact_sum` — `add_rms_forward` returns the pre-normalization sum **bit-exactly** (`rtol=atol=0`).

### 2. Euler pre-alloc regression — `tests/unit/test_voxcpm2_euler_prealloc.py` (new)
`solve_euler` had zero coverage. Using a capturing fake estimator:
- `test_euler_unconditioned_mu_half_is_zeroed` — the CFG unconditioned half of `mu_in` is zero. This is the one buffer that previously relied on `torch.zeros` and now needs an explicit `mu_in[bsz:].zero_()` after the switch to `torch.empty` — the highest-risk change in #67.
- `test_euler_buffers_fully_overwritten_each_step` — `x_in`/`cond_in` are fully written every step (no stale/garbage from the reused empty buffers).
- `test_euler_dt_zeroed_when_not_mean_mode` — guards the `dt_in.zero_()` branch.

### 3. Fix broken TP test — `tests/unit/test_linear_layers.py`
`test_column_parallel_linear_weight_loader_shards` was **failing on `main`**
(independent of #67). It monkeypatched `linear.dist.get_world_size/get_rank`,
but `ColumnParallelLinear` reads tp size/rank via `get_tp_world_size/get_tp_rank`.
Those short-circuit to `1`/`0` when TP is uninitialized and never call
`dist.get_world_size`, so the patch was a no-op and the weight was left
unsharded. Now patches `linear.get_tp_world_size/get_tp_rank`.

### 4. Black-format #67's Euler block — `nanovllm_voxcpm/models/voxcpm2/model.py`
#67 left manually-aligned assignments and inline semicolons in `solve_euler`
that fail `black --check .` (black 26.3.1). Pure formatting, no behavior change.

## Verification

- Full unit suite: **139 passed, 0 failed** (was 138 passed + 1 failed).
- Local CI parity: `compileall`, `ruff check . --select F,E9`, `black --check .`, `mypy` all clean.
- Each new/fixed test was **mutation-verified** to actually catch the bug it guards:
  - removing `mu_in[bsz:].zero_()` → Euler test fails
  - dropping the RMSNorm weight → numeric test fails
  - forcing shard `start_idx = 0` → linear TP test fails