### PR TITLE
perf(serving): optimize diffusion, LoRA, and VAE hot paths

### DIFF
--- a/benchmark/calibrate_waveform.py
+++ b/benchmark/calibrate_waveform.py
@@ -1,0 +1,106 @@
+"""Generate a deterministic waveform and optionally compare it with a reference."""
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def compare_waveforms(actual: np.ndarray, reference: np.ndarray) -> dict[str, float | int]:
+    common_samples = min(actual.size, reference.size)
+    actual_common = actual[:common_samples].astype(np.float64)
+    reference_common = reference[:common_samples].astype(np.float64)
+    error = actual_common - reference_common
+    centered_actual = actual_common - float(actual_common.mean())
+    centered_reference = reference_common - float(reference_common.mean())
+    denominator = np.linalg.norm(centered_actual) * np.linalg.norm(centered_reference)
+    correlation = float(np.dot(centered_actual, centered_reference) / denominator) if denominator else 1.0
+    return {
+        "actual_samples": int(actual.size),
+        "reference_samples": int(reference.size),
+        "common_samples": common_samples,
+        "rmse": float(np.sqrt(np.mean(error**2))),
+        "abs_error_p99_9": float(np.percentile(np.abs(error), 99.9)),
+        "max_abs_error": float(np.max(np.abs(error))),
+        "correlation": correlation,
+    }
+
+
+async def async_main(args: argparse.Namespace) -> None:
+    from nanovllm_voxcpm import VoxCPM
+
+    target_text = (
+        Path(args.target_text_file).read_text(encoding="utf-8").strip()
+        if args.target_text_file
+        else args.target_text
+    )
+    server_pool = VoxCPM.from_pretrained(
+        model=args.model,
+        inference_timesteps=args.inference_timesteps,
+        max_num_batched_tokens=16384,
+        max_num_seqs=512,
+        max_model_len=4096,
+        gpu_memory_utilization=0.9,
+        devices=[args.device],
+        enforce_eager=args.enforce_eager,
+    )
+    async def generate_one(seed: int) -> np.ndarray:
+        chunks = []
+        async for chunk in server_pool.generate(
+            target_text=target_text,
+            max_generate_length=args.max_generate_length,
+            temperature=args.temperature,
+            cfg_value=args.cfg_value,
+            seed=seed,
+        ):
+            chunks.append(np.asarray(chunk, dtype=np.float32))
+        return np.concatenate(chunks) if chunks else np.empty(0, dtype=np.float32)
+
+    try:
+        await server_pool.wait_for_ready()
+        waveforms = await asyncio.gather(*(generate_one(args.seed + index) for index in range(args.concurrency)))
+    finally:
+        await server_pool.stop()
+
+    if args.concurrency == 1:
+        np.save(args.output, waveforms[0])
+    else:
+        np.savez(args.output, **{f"request_{index}": waveform for index, waveform in enumerate(waveforms)})
+    result: dict[str, object] = {
+        "output": str(Path(args.output).resolve()),
+        "num_samples": [int(waveform.size) for waveform in waveforms],
+    }
+    if args.reference:
+        reference = np.load(args.reference)
+        if args.concurrency == 1:
+            result["comparison"] = compare_waveforms(waveforms[0], reference)
+        else:
+            result["comparison"] = [
+                compare_waveforms(waveform, reference[f"request_{index}"])
+                for index, waveform in enumerate(waveforms)
+            ]
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--reference")
+    parser.add_argument("--target-text", default="Hello world.")
+    parser.add_argument("--target-text-file")
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--inference-timesteps", type=int, default=10)
+    parser.add_argument("--max-generate-length", type=int, default=2000)
+    parser.add_argument("--temperature", type=float, default=1.0)
+    parser.add_argument("--cfg-value", type=float, default=2.0)
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--enforce-eager", action="store_true")
+    asyncio.run(async_main(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/calibrate_waveform.py
+++ b/benchmark/calibrate_waveform.py
@@ -8,7 +8,9 @@ from pathlib import Path
 import numpy as np
 
 
-def compare_waveforms(actual: np.ndarray, reference: np.ndarray) -> dict[str, float | int]:
+def compare_waveforms(actual: np.ndarray, reference: np.ndarray) -> dict[str, float | int | bool]:
+    if actual.size == 0 or reference.size == 0:
+        raise ValueError("waveform comparison requires non-empty actual and reference arrays")
     common_samples = min(actual.size, reference.size)
     actual_common = actual[:common_samples].astype(np.float64)
     reference_common = reference[:common_samples].astype(np.float64)
@@ -16,11 +18,15 @@ def compare_waveforms(actual: np.ndarray, reference: np.ndarray) -> dict[str, fl
     centered_actual = actual_common - float(actual_common.mean())
     centered_reference = reference_common - float(reference_common.mean())
     denominator = np.linalg.norm(centered_actual) * np.linalg.norm(centered_reference)
-    correlation = float(np.dot(centered_actual, centered_reference) / denominator) if denominator else 1.0
+    if denominator:
+        correlation = float(np.dot(centered_actual, centered_reference) / denominator)
+    else:
+        correlation = 1.0 if np.array_equal(actual_common, reference_common) else 0.0
     return {
         "actual_samples": int(actual.size),
         "reference_samples": int(reference.size),
         "common_samples": common_samples,
+        "length_match": actual.size == reference.size,
         "rmse": float(np.sqrt(np.mean(error**2))),
         "abs_error_p99_9": float(np.percentile(np.abs(error), 99.9)),
         "max_abs_error": float(np.max(np.abs(error))),
@@ -28,13 +34,35 @@ def compare_waveforms(actual: np.ndarray, reference: np.ndarray) -> dict[str, fl
     }
 
 
+def comparison_failures(
+    comparison: dict[str, float | int | bool],
+    *,
+    require_same_length: bool,
+    max_rmse: float | None,
+    max_abs_error: float | None,
+    min_correlation: float | None,
+) -> list[str]:
+    failures = []
+    if require_same_length and not comparison["length_match"]:
+        failures.append(
+            f"sample count mismatch: actual={comparison['actual_samples']} reference={comparison['reference_samples']}"
+        )
+    if max_rmse is not None and comparison["rmse"] > max_rmse:
+        failures.append(f"rmse {comparison['rmse']:.6g} exceeds {max_rmse:.6g}")
+    if max_abs_error is not None and comparison["max_abs_error"] > max_abs_error:
+        failures.append(f"max_abs_error {comparison['max_abs_error']:.6g} exceeds {max_abs_error:.6g}")
+    if min_correlation is not None and comparison["correlation"] < min_correlation:
+        failures.append(f"correlation {comparison['correlation']:.9g} is below {min_correlation:.9g}")
+    return failures
+
+
 async def async_main(args: argparse.Namespace) -> None:
     from nanovllm_voxcpm import VoxCPM
 
+    if args.concurrency < 1:
+        raise ValueError("concurrency must be at least 1")
     target_text = (
-        Path(args.target_text_file).read_text(encoding="utf-8").strip()
-        if args.target_text_file
-        else args.target_text
+        Path(args.target_text_file).read_text(encoding="utf-8").strip() if args.target_text_file else args.target_text
     )
     server_pool = VoxCPM.from_pretrained(
         model=args.model,
@@ -46,6 +74,7 @@ async def async_main(args: argparse.Namespace) -> None:
         devices=[args.device],
         enforce_eager=args.enforce_eager,
     )
+
     async def generate_one(seed: int) -> np.ndarray:
         chunks = []
         async for chunk in server_pool.generate(
@@ -72,16 +101,32 @@ async def async_main(args: argparse.Namespace) -> None:
         "output": str(Path(args.output).resolve()),
         "num_samples": [int(waveform.size) for waveform in waveforms],
     }
+    failures = []
     if args.reference:
         reference = np.load(args.reference)
         if args.concurrency == 1:
-            result["comparison"] = compare_waveforms(waveforms[0], reference)
+            comparisons = [compare_waveforms(waveforms[0], reference)]
+            result["comparison"] = comparisons[0]
         else:
-            result["comparison"] = [
-                compare_waveforms(waveform, reference[f"request_{index}"])
-                for index, waveform in enumerate(waveforms)
+            comparisons = [
+                compare_waveforms(waveform, reference[f"request_{index}"]) for index, waveform in enumerate(waveforms)
             ]
+            result["comparison"] = comparisons
+        for index, comparison in enumerate(comparisons):
+            request_failures = comparison_failures(
+                comparison,
+                require_same_length=not args.allow_length_mismatch,
+                max_rmse=args.max_rmse,
+                max_abs_error=args.max_abs_error,
+                min_correlation=args.min_correlation,
+            )
+            failures.extend(f"request_{index}: {failure}" for failure in request_failures)
+        result["comparison_passed"] = not failures
+        if failures:
+            result["failures"] = failures
     print(json.dumps(result, indent=2, sort_keys=True))
+    if failures:
+        raise SystemExit(1)
 
 
 def main() -> None:
@@ -99,6 +144,10 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=123)
     parser.add_argument("--concurrency", type=int, default=1)
     parser.add_argument("--enforce-eager", action="store_true")
+    parser.add_argument("--allow-length-mismatch", action="store_true")
+    parser.add_argument("--max-rmse", type=float)
+    parser.add_argument("--max-abs-error", type=float)
+    parser.add_argument("--min-correlation", type=float)
     asyncio.run(async_main(parser.parse_args()))
 
 

--- a/nanovllm_voxcpm/engine/llm_engine.py
+++ b/nanovllm_voxcpm/engine/llm_engine.py
@@ -189,6 +189,7 @@ class LLMEngineBase:
     def on_seq_removed(self, seq: Sequence, *, was_running: bool) -> None:
         self.lora_manager.on_sequence_finished(seq.adapter_id, was_running=was_running)
         self.model_runner.call("lora_on_sequence_finished", seq.adapter_id, was_running)
+        self.model_runner.call("release_sequence_state", seq.seq_id)
 
     def step(self):
         seqs, is_prefill = self.scheduler.schedule()

--- a/nanovllm_voxcpm/engine/lora_manager.py
+++ b/nanovllm_voxcpm/engine/lora_manager.py
@@ -142,7 +142,21 @@ def _pack_int_tensors_to_cuda(*lists: list[int]) -> list[torch.Tensor]:
     return out
 
 
-def build_lora_context_from_batch_plan(plan: LoRABatchPlan) -> LoRAContext:
+def build_lora_context_from_batch_plan(
+    plan: LoRABatchPlan,
+    *,
+    materialize_device: bool = True,
+) -> LoRAContext:
+    if not materialize_device:
+        return LoRAContext(
+            no_lora_flag=not plan.active_slot_ids,
+            num_active_loras=len(plan.active_slot_ids),
+            host_token_to_slot=plan.token_to_slot,
+            host_token_indices_sorted_by_slot=plan.token_indices_sorted_by_slot,
+            host_active_slot_ids=plan.active_slot_ids,
+            host_num_tokens_per_slot=plan.num_tokens_per_slot,
+        )
+
     if not plan.active_slot_ids:
         token_to_slot_tensor = _cuda_int_tensor(plan.token_to_slot)
         return LoRAContext(
@@ -184,8 +198,35 @@ def build_lora_context_from_batch_plan(plan: LoRABatchPlan) -> LoRAContext:
     )
 
 
-def build_lora_context_from_slot_list(token_to_slot: list[int]) -> LoRAContext:
-    return build_lora_context_from_batch_plan(build_lora_batch_plan_from_token_to_slot({}, token_to_slot))
+def build_lora_context_from_slot_list(
+    token_to_slot: list[int],
+    *,
+    materialize_device: bool = True,
+) -> LoRAContext:
+    return build_lora_context_from_batch_plan(
+        build_lora_batch_plan_from_token_to_slot({}, token_to_slot),
+        materialize_device=materialize_device,
+    )
+
+
+def materialize_lora_context(context: LoRAContext) -> LoRAContext:
+    """Create device metadata for a host-only graph context on eager fallback."""
+    if context.token_to_slot is not None or context.host_token_to_slot is None:
+        return context
+
+    host_counts = context.host_num_tokens_per_slot or []
+    slot_start_offsets = [0]
+    for count in host_counts:
+        slot_start_offsets.append(slot_start_offsets[-1] + count)
+    plan = LoRABatchPlan(
+        adapter_to_slot={},
+        token_to_slot=context.host_token_to_slot,
+        token_indices_sorted_by_slot=context.host_token_indices_sorted_by_slot or [],
+        active_slot_ids=context.host_active_slot_ids or [],
+        num_tokens_per_slot=host_counts,
+        slot_start_offsets=slot_start_offsets,
+    )
+    return build_lora_context_from_batch_plan(plan)
 
 
 class _LoRAStateBase:

--- a/nanovllm_voxcpm/engine/lora_manager.py
+++ b/nanovllm_voxcpm/engine/lora_manager.py
@@ -149,6 +149,10 @@ def build_lora_context_from_batch_plan(plan: LoRABatchPlan) -> LoRAContext:
             token_to_slot=token_to_slot_tensor,
             no_lora_flag=True,
             num_active_loras=0,
+            host_token_to_slot=plan.token_to_slot,
+            host_token_indices_sorted_by_slot=plan.token_indices_sorted_by_slot,
+            host_active_slot_ids=plan.active_slot_ids,
+            host_num_tokens_per_slot=plan.num_tokens_per_slot,
         )
 
     (
@@ -173,6 +177,10 @@ def build_lora_context_from_batch_plan(plan: LoRABatchPlan) -> LoRAContext:
         slot_start_offsets=slot_start_offsets_tensor,
         no_lora_flag=False,
         num_active_loras=len(plan.active_slot_ids),
+        host_token_to_slot=plan.token_to_slot,
+        host_token_indices_sorted_by_slot=plan.token_indices_sorted_by_slot,
+        host_active_slot_ids=plan.active_slot_ids,
+        host_num_tokens_per_slot=plan.num_tokens_per_slot,
     )
 
 

--- a/nanovllm_voxcpm/engine/model_runner.py
+++ b/nanovllm_voxcpm/engine/model_runner.py
@@ -96,6 +96,7 @@ from nanovllm_voxcpm.utils.context import (
     LM_LORA_DOMAIN,
     PROJ_LORA_DOMAIN,
     LoRAContext,
+    build_lora_context_from_token_to_slot,
     get_context,
     get_lora_context,
     reset_all_contexts,
@@ -139,6 +140,7 @@ class RunnerTask(Generic[PlayloadType]):
         block_size: int,
         custom_payload: PlayloadType = None,
         adapter_id: int | None = None,
+        seq_id: str | None = None,
     ):
         self.block_table = block_table
         self.seq_length = seq_length
@@ -146,6 +148,7 @@ class RunnerTask(Generic[PlayloadType]):
         self.custom_payload = custom_payload
         self.block_size = block_size
         self.adapter_id = adapter_id
+        self.seq_id = seq_id
 
     @property
     def num_blocks(self):
@@ -175,9 +178,20 @@ def expand_dit_lora_slots(
     sample_to_slot: list[int],
     sequence_length: int,
     cfg_branches: int,
+    padded_batch_size: int | None = None,
 ) -> list[int]:
-    """Expand sample slots in the branch-major order used by CFG."""
-    return [slot for _ in range(cfg_branches) for slot in sample_to_slot for _ in range(sequence_length)]
+    """Expand sample-level slots in the branch-major order used by CFG.
+
+    Diffusion constructs its estimator batch as all positive samples followed
+    by all negative samples. CUDA graph batch padding must therefore be
+    inserted at the end of each CFG branch rather than once at the end.
+    """
+    batch_size = len(sample_to_slot)
+    padded_batch_size = batch_size if padded_batch_size is None else padded_batch_size
+    if padded_batch_size < batch_size:
+        raise ValueError("padded_batch_size cannot be smaller than the real batch size")
+    padded_slots = sample_to_slot + [-1] * (padded_batch_size - batch_size)
+    return [slot for _ in range(cfg_branches) for slot in padded_slots for _ in range(sequence_length)]
 
 
 def _clear_lora_slot_modules(modules, slot_id: int, module_names: list[str] | None = None) -> None:
@@ -323,16 +337,22 @@ class BaseModelRunner:
         sample_to_slot = [
             plan.adapter_to_slot.get(adapter_id, -1) if adapter_id is not None else -1 for adapter_id in adapter_ids
         ]
+        padded_batch_size = len(sample_to_slot)
+        if not getattr(self, "enforce_eager", True) and hasattr(self, "graph_bs"):
+            padded_batch_size = next(
+                (graph_bs for graph_bs in self.graph_bs if graph_bs >= len(sample_to_slot)),
+                len(sample_to_slot),
+            )
+        dit_token_to_slot = expand_dit_lora_slots(
+            sample_to_slot,
+            sequence_length=self._dit_lora_sequence_length(),
+            cfg_branches=self.cfg_branches,
+            padded_batch_size=padded_batch_size,
+        )
         return {
             LM_LORA_DOMAIN: build_lora_context_from_batch_plan(plan),
             PROJ_LORA_DOMAIN: build_lora_context_from_slot_list(sample_to_slot),
-            DIT_LORA_DOMAIN: build_lora_context_from_slot_list(
-                expand_dit_lora_slots(
-                    sample_to_slot,
-                    sequence_length=self._dit_lora_sequence_length(),
-                    cfg_branches=self.cfg_branches,
-                )
-            ),
+            DIT_LORA_DOMAIN: build_lora_context_from_slot_list(dit_token_to_slot),
         }
 
     def _lora_model_modules(self) -> dict[str, torch.nn.Module]:
@@ -401,6 +421,11 @@ class BaseModelRunner:
     def lora_on_sequence_finished(self, adapter_id: int | None, was_running: bool) -> None:
         self.lora_runtime.on_sequence_finished(adapter_id, was_running=was_running)
 
+    def release_sequence_state(self, seq_id: str) -> None:
+        vae_decoder = getattr(self, "vae_streaming_decoder", None)
+        if vae_decoder is not None:
+            vae_decoder.release(seq_id)
+
     def _load_lora_slot(self, slot_id: int, payload: LoRAModelPayload) -> None:
         modules = self._lora_model_modules()
         # Only clear modules that the previous occupant of this slot actually
@@ -412,7 +437,10 @@ class BaseModelRunner:
             slot_modules = {}
             self._lora_slot_modules = slot_modules
         previously_loaded = slot_modules.get(slot_id)
-        _clear_lora_slot_modules(modules, slot_id, module_names=previously_loaded)
+        if previously_loaded is not None:
+            incoming_modules = set(payload.modules)
+            removed_modules = [name for name in previously_loaded if name not in incoming_modules]
+            _clear_lora_slot_modules(modules, slot_id, module_names=removed_modules)
         for module_name, module_payload in payload.modules.items():
             try:
                 module = modules[module_name]
@@ -578,6 +606,8 @@ class BaseModelRunner:
             dist.destroy_process_group()
         if not self.enforce_eager:
             del self.graphs, self.graph_pool
+            if hasattr(self, "prefill_diffusion_graphs"):
+                del self.prefill_diffusion_graphs, self.prefill_diffusion_graph_vars
         torch.cuda.synchronize()
 
     def loop(self):
@@ -730,13 +760,55 @@ class BaseModelRunner:
             set_lora_context(lora_context, domain=domain)
         return positions
 
-    def _make_graph_domain_buffers(self, max_rows: int, max_lora_buckets: int) -> dict[str, torch.Tensor]:
+    def _make_graph_domain_buffers(self, max_rows: int, max_lora_buckets: int) -> dict:
+        sizes = (
+            max_rows,
+            max_rows,
+            max_lora_buckets,
+            max_lora_buckets,
+            max_lora_buckets + 1,
+        )
+        total_size = sum(sizes)
+        packed = torch.empty(total_size, dtype=torch.int32)
+        host_staging = torch.empty(total_size, dtype=torch.int32, device="cpu", pin_memory=True)
+        offsets = [0]
+        for size in sizes:
+            offsets.append(offsets[-1] + size)
+
+        def views(buffer: torch.Tensor):
+            return (
+                buffer[offsets[0] : offsets[1]],
+                buffer[offsets[1] : offsets[2]],
+                buffer[offsets[2] : offsets[3]],
+                buffer[offsets[3] : offsets[4]],
+                buffer[offsets[4] : offsets[5]],
+            )
+
+        token_to_slot, token_indices, active_slot_ids, num_tokens, slot_offsets = views(packed)
+        host_token_to_slot, host_token_indices, host_active_slot_ids, host_num_tokens, host_slot_offsets = views(
+            host_staging
+        )
+        host_token_to_slot.fill_(-1)
+        host_token_indices.copy_(torch.arange(max_rows, dtype=torch.int32))
+        host_active_slot_ids.copy_(torch.arange(-1, max_lora_buckets - 1, dtype=torch.int32))
+        host_num_tokens.zero_()
+        host_slot_offsets.zero_()
+        packed.copy_(host_staging, non_blocking=True)
         return {
-            "token_to_slot": torch.full((max_rows,), -1, dtype=torch.int32),
-            "token_indices_sorted_by_slot": torch.arange(max_rows, dtype=torch.int32),
-            "active_slot_ids": torch.arange(-1, max_lora_buckets - 1, dtype=torch.int32),
-            "num_tokens_per_slot": torch.zeros(max_lora_buckets, dtype=torch.int32),
-            "slot_start_offsets": torch.zeros(max_lora_buckets + 1, dtype=torch.int32),
+            "packed": packed,
+            "host_staging": host_staging,
+            "copy_event": torch.cuda.Event(),
+            "copy_pending": False,
+            "token_to_slot": token_to_slot,
+            "token_indices_sorted_by_slot": token_indices,
+            "active_slot_ids": active_slot_ids,
+            "num_tokens_per_slot": num_tokens,
+            "slot_start_offsets": slot_offsets,
+            "host_token_to_slot": host_token_to_slot,
+            "host_token_indices_sorted_by_slot": host_token_indices,
+            "host_active_slot_ids": host_active_slot_ids,
+            "host_num_tokens_per_slot": host_num_tokens,
+            "host_slot_start_offsets": host_slot_offsets,
         }
 
     def _copy_lora_domain_to_graph_vars(
@@ -754,15 +826,9 @@ class BaseModelRunner:
         metadata shuffling, dominating the LoRA RTF regression.
 
         We now precompute the final-form slices on CPU (int32), pack them into
-        one pinned buffer, and issue a single H2D copy — plus a single cumsum
-        on GPU for ``slot_start_offsets`` (we still derive it from
-        ``num_tokens_per_slot`` on-device to keep the final tensor consistent
-        with what kernels read).
-
-        The ``no_lora_flag`` case is specialised to a tiny ``fill_(-1)`` on
-        ``token_to_slot`` — all other buffers were preallocated to the correct
-        sentinel state at capture time and kernels short-circuit on
-        ``no_lora`` anyway.
+        one pinned buffer, and issue a single H2D copy for the entire domain.
+        The same packed transfer restores the sentinel state for batches
+        without active LoRA adapters.
         """
         domain_vars = graph_vars["lora_domains"][domain]
         token_to_slot_buf: torch.Tensor = domain_vars["token_to_slot"]
@@ -771,6 +837,41 @@ class BaseModelRunner:
         slot_start_buf: torch.Tensor = domain_vars["slot_start_offsets"]
 
         token_count = 0 if context.token_to_slot is None else context.token_to_slot.size(0)
+        has_host_metadata = context.host_token_to_slot is not None
+        if "host_staging" in domain_vars and (context.no_lora_flag or has_host_metadata):
+            if domain_vars["copy_pending"]:
+                domain_vars["copy_event"].synchronize()
+
+            host_token_to_slot = domain_vars["host_token_to_slot"]
+            host_token_indices = domain_vars["host_token_indices_sorted_by_slot"]
+            host_num_tokens = domain_vars["host_num_tokens_per_slot"]
+            host_slot_offsets = domain_vars["host_slot_start_offsets"]
+            host_token_to_slot.fill_(-1)
+            host_num_tokens.zero_()
+            host_slot_offsets.zero_()
+
+            if not context.no_lora_flag:
+                host_slots = context.host_token_to_slot or []
+                host_indices = context.host_token_indices_sorted_by_slot or []
+                host_active_ids = context.host_active_slot_ids or []
+                host_counts = context.host_num_tokens_per_slot or []
+                if len(host_slots) > host_token_to_slot.numel():
+                    raise ValueError("LoRA token metadata exceeds captured CUDA graph capacity")
+                host_token_to_slot[: len(host_slots)].copy_(torch.tensor(host_slots, dtype=torch.int32))
+                host_token_indices[: len(host_indices)].copy_(torch.tensor(host_indices, dtype=torch.int32))
+                fixed_counts = [0] * host_num_tokens.numel()
+                for slot_id, count in zip(host_active_ids, host_counts):
+                    fixed_counts[slot_id + 1] = count
+                fixed_offsets = [0]
+                for count in fixed_counts:
+                    fixed_offsets.append(fixed_offsets[-1] + count)
+                host_num_tokens.copy_(torch.tensor(fixed_counts, dtype=torch.int32))
+                host_slot_offsets.copy_(torch.tensor(fixed_offsets, dtype=torch.int32))
+
+            domain_vars["packed"].copy_(domain_vars["host_staging"], non_blocking=True)
+            domain_vars["copy_event"].record()
+            domain_vars["copy_pending"] = True
+            return
 
         if context.no_lora_flag or context.token_to_slot is None:
             # Kernels bail out on no_lora; we only need token_to_slot to be
@@ -811,25 +912,27 @@ class BaseModelRunner:
         slot_start_buf[0] = 0
         torch.cumsum(num_tokens_buf, dim=0, out=slot_start_buf[1:])
 
+    def _set_graph_lora_context(self, graph_vars: dict, domain: str, context: LoRAContext) -> None:
+        self._copy_lora_domain_to_graph_vars(graph_vars, domain, context)
+        domain_vars = graph_vars["lora_domains"][domain]
+        token_count = 0 if context.token_to_slot is None else context.token_to_slot.size(0)
+        num_lora_buckets = domain_vars["active_slot_ids"].size(0)
+        set_lora_context(
+            LoRAContext(
+                token_to_slot=domain_vars["token_to_slot"][:token_count],
+                token_indices_sorted_by_slot=domain_vars["token_indices_sorted_by_slot"][:token_count],
+                active_slot_ids=domain_vars["active_slot_ids"],
+                num_tokens_per_slot=domain_vars["num_tokens_per_slot"],
+                slot_start_offsets=domain_vars["slot_start_offsets"],
+                no_lora_flag=context.no_lora_flag,
+                num_active_loras=num_lora_buckets,
+            ),
+            domain=domain,
+        )
+
     def _set_graph_lora_contexts(self, graph_vars: dict, contexts: dict[str, LoRAContext]) -> None:
         for domain in LORA_DOMAINS:
-            context = contexts[domain]
-            self._copy_lora_domain_to_graph_vars(graph_vars, domain, context)
-            domain_vars = graph_vars["lora_domains"][domain]
-            token_count = 0 if context.token_to_slot is None else context.token_to_slot.size(0)
-            num_lora_buckets = domain_vars["active_slot_ids"].size(0)
-            set_lora_context(
-                LoRAContext(
-                    token_to_slot=domain_vars["token_to_slot"][:token_count],
-                    token_indices_sorted_by_slot=domain_vars["token_indices_sorted_by_slot"][:token_count],
-                    active_slot_ids=domain_vars["active_slot_ids"],
-                    num_tokens_per_slot=domain_vars["num_tokens_per_slot"],
-                    slot_start_offsets=domain_vars["slot_start_offsets"],
-                    no_lora_flag=context.no_lora_flag,
-                    num_active_loras=num_lora_buckets,
-                ),
-                domain=domain,
-            )
+            self._set_graph_lora_context(graph_vars, domain, contexts[domain])
 
     @torch.inference_mode()
     def capture_cudagraph(self):
@@ -936,6 +1039,121 @@ class BaseModelRunner:
             lora_domains=lora_domains,
             outputs=outputs,
         )
+        self.capture_prefill_diffusion_cudagraph()
+
+    @torch.inference_mode()
+    def capture_prefill_diffusion_cudagraph(self) -> None:
+        make_dummy_inputs = getattr(self.model, "make_dummy_diffusion_inputs", None)
+        forward_diffusion = getattr(self.model, "forward_diffusion", None)
+        forward_backbone = getattr(self.model, "forward_backbone", None)
+        if not callable(make_dummy_inputs) or not callable(forward_diffusion) or not callable(forward_backbone):
+            return
+
+        max_bs = max(self.graph_bs)
+        inputs = make_dummy_inputs(max_bs)
+        cond = inputs["cond"]
+        outputs = torch.zeros(max_bs, self.patch_size, cond.size(1), dtype=cond.dtype, device=cond.device)
+        dit_rows_per_sample = self._dit_lora_rows_per_sample()
+        max_lora_buckets = self.max_loras + 1
+        graph_vars = {
+            "inputs": inputs,
+            "outputs": outputs,
+            "lora_domains": {
+                DIT_LORA_DOMAIN: self._make_graph_domain_buffers(
+                    dit_rows_per_sample * max_bs,
+                    max_lora_buckets,
+                )
+            },
+        }
+        self.prefill_diffusion_graphs = {"base": {}, "lora": {}}
+        capture_lora_graphs = bool(
+            self._config.lora_config is not None
+            and getattr(self._config.lora_config, "enable_dit", False)
+            and is_lora_available()
+        )
+
+        for bs in reversed(self.graph_bs):
+            dit_rows = dit_rows_per_sample * bs
+            base_context = build_lora_context_from_slot_list([-1] * dit_rows)
+            self._set_graph_lora_context(graph_vars, DIT_LORA_DOMAIN, base_context)
+            outputs[:bs] = forward_diffusion(**cut_inputs(inputs, bs))
+
+            base_graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(base_graph, self.graph_pool):
+                outputs[:bs] = forward_diffusion(**cut_inputs(inputs, bs))
+            self.prefill_diffusion_graphs["base"][bs] = base_graph
+
+            if capture_lora_graphs:
+                lora_context = build_lora_context_from_slot_list([0] * dit_rows)
+                self._set_graph_lora_context(graph_vars, DIT_LORA_DOMAIN, lora_context)
+                outputs[:bs] = forward_diffusion(**cut_inputs(inputs, bs))
+
+                lora_graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(lora_graph, self.graph_pool):
+                    outputs[:bs] = forward_diffusion(**cut_inputs(inputs, bs))
+                self.prefill_diffusion_graphs["lora"][bs] = lora_graph
+
+            torch.cuda.synchronize()
+            reset_all_contexts()
+
+        self.prefill_diffusion_graph_vars = graph_vars
+
+    def _run_prefill_with_diffusion_graph(
+        self,
+        inputs: dict[str, torch.Tensor],
+        lora_contexts: dict[str, LoRAContext],
+    ):
+        diffusion_inputs, outputs = self.model.forward_backbone(**inputs)
+        batch_size = diffusion_inputs["mu"].size(0)
+        dit_context = lora_contexts[DIT_LORA_DOMAIN]
+
+        def run_diffusion_eager():
+            sequence_length = self._dit_lora_sequence_length()
+            token_to_slot = dit_context.token_to_slot
+            if not dit_context.no_lora_flag and token_to_slot is not None and sequence_length > 0:
+                rows_per_branch = token_to_slot.numel() // self.cfg_branches
+                padded_batch_size = rows_per_branch // sequence_length
+                if padded_batch_size > batch_size:
+                    real_rows_per_branch = batch_size * sequence_length
+                    token_to_slot = torch.cat(
+                        [
+                            token_to_slot[branch * rows_per_branch : branch * rows_per_branch + real_rows_per_branch]
+                            for branch in range(self.cfg_branches)
+                        ]
+                    )
+                    set_lora_context(
+                        build_lora_context_from_token_to_slot(token_to_slot),
+                        domain=DIT_LORA_DOMAIN,
+                    )
+            outputs["latents"] = self.model.forward_diffusion(**diffusion_inputs)
+            return outputs
+
+        z_noise = diffusion_inputs.get("z_noise")
+        if batch_size > self.graph_bs[-1] or z_noise is None:
+            return run_diffusion_eager()
+
+        has_active_dit_lora = (
+            not dit_context.no_lora_flag
+            and dit_context.token_to_slot is not None
+            and dit_context.token_to_slot.numel() > 0
+        )
+        graph_kind = "lora" if has_active_dit_lora else "base"
+        graphs = self.prefill_diffusion_graphs[graph_kind]
+        if not graphs:
+            return run_diffusion_eager()
+
+        graph_bs = next(bs for bs in self.graph_bs if bs >= batch_size)
+        graph_vars = self.prefill_diffusion_graph_vars
+        for name, value in diffusion_inputs.items():
+            buffer = graph_vars["inputs"][name]
+            buffer[:batch_size].copy_(value)
+            if batch_size < graph_bs:
+                buffer[batch_size:graph_bs].zero_()
+
+        self._set_graph_lora_context(graph_vars, DIT_LORA_DOMAIN, dit_context)
+        graphs[graph_bs].replay()
+        outputs["latents"] = graph_vars["outputs"][:batch_size]
+        return outputs
 
     @torch.inference_mode()
     def run_model(self, inputs: dict, is_prefill: bool):
@@ -945,6 +1163,13 @@ class BaseModelRunner:
         )
         has_lora_graph = has_active_lora and bool(getattr(self, "graphs", {}).get("lora"))
         try:
+            if (
+                is_prefill
+                and not self.enforce_eager
+                and hasattr(self, "prefill_diffusion_graphs")
+                and hasattr(self.model, "forward_backbone")
+            ):
+                return self._run_prefill_with_diffusion_graph(inputs, lora_contexts)
             if (
                 is_prefill
                 or self.enforce_eager

--- a/nanovllm_voxcpm/engine/model_runner.py
+++ b/nanovllm_voxcpm/engine/model_runner.py
@@ -87,6 +87,7 @@ from nanovllm_voxcpm.engine.lora_manager import (
     LoRARuntime,
     build_lora_context_from_batch_plan,
     build_lora_context_from_slot_list,
+    materialize_lora_context,
 )
 from nanovllm_voxcpm.layers.attention import Attention
 from nanovllm_voxcpm.layers.lora import iter_lora_modules
@@ -317,7 +318,15 @@ class BaseModelRunner:
     def _dit_lora_rows_per_sample(self) -> int:
         return self.cfg_branches * self._dit_lora_sequence_length()
 
-    def _build_lora_contexts(self, seqs: list[RunnerTask], token_counts: list[int]) -> dict[str, LoRAContext]:
+    def _build_lora_contexts(
+        self,
+        seqs: list[RunnerTask],
+        token_counts: list[int],
+        *,
+        materialize_domains: set[str] | None = None,
+    ) -> dict[str, LoRAContext]:
+        if materialize_domains is None:
+            materialize_domains = set(LORA_DOMAINS)
         adapter_ids = [seq.adapter_id for seq in seqs]
         if not any(adapter_id is not None for adapter_id in adapter_ids):
             # No active LoRA anywhere in this batch. Build just the LM
@@ -328,7 +337,10 @@ class BaseModelRunner:
             # tensor.
             empty_ctx = LoRAContext(no_lora_flag=True, num_active_loras=0)
             return {
-                LM_LORA_DOMAIN: build_lora_context_from_slot_list([-1] * sum(token_counts)),
+                LM_LORA_DOMAIN: build_lora_context_from_slot_list(
+                    [-1] * sum(token_counts),
+                    materialize_device=LM_LORA_DOMAIN in materialize_domains,
+                ),
                 PROJ_LORA_DOMAIN: empty_ctx,
                 DIT_LORA_DOMAIN: empty_ctx,
             }
@@ -350,9 +362,18 @@ class BaseModelRunner:
             padded_batch_size=padded_batch_size,
         )
         return {
-            LM_LORA_DOMAIN: build_lora_context_from_batch_plan(plan),
-            PROJ_LORA_DOMAIN: build_lora_context_from_slot_list(sample_to_slot),
-            DIT_LORA_DOMAIN: build_lora_context_from_slot_list(dit_token_to_slot),
+            LM_LORA_DOMAIN: build_lora_context_from_batch_plan(
+                plan,
+                materialize_device=LM_LORA_DOMAIN in materialize_domains,
+            ),
+            PROJ_LORA_DOMAIN: build_lora_context_from_slot_list(
+                sample_to_slot,
+                materialize_device=PROJ_LORA_DOMAIN in materialize_domains,
+            ),
+            DIT_LORA_DOMAIN: build_lora_context_from_slot_list(
+                dit_token_to_slot,
+                materialize_device=DIT_LORA_DOMAIN in materialize_domains,
+            ),
         }
 
     def _lora_model_modules(self) -> dict[str, torch.nn.Module]:
@@ -734,7 +755,17 @@ class BaseModelRunner:
             block_tables,
         )
         token_counts = [seq.seq_length - seq.num_cached_tokens for seq in seqs]
-        for domain, lora_context in self._build_lora_contexts(seqs, token_counts).items():
+        use_diffusion_graph = (
+            not getattr(self, "enforce_eager", True)
+            and hasattr(self, "prefill_diffusion_graphs")
+            and hasattr(self.model, "forward_backbone")
+        )
+        materialize_domains = {LM_LORA_DOMAIN, PROJ_LORA_DOMAIN} if use_diffusion_graph else set(LORA_DOMAINS)
+        for domain, lora_context in self._build_lora_contexts(
+            seqs,
+            token_counts,
+            materialize_domains=materialize_domains,
+        ).items():
             set_lora_context(lora_context, domain=domain)
         return positions
 
@@ -756,7 +787,12 @@ class BaseModelRunner:
             context_lens=context_lens,
             block_tables=block_tables,
         )
-        for domain, lora_context in self._build_lora_contexts(seqs, [1 for _ in seqs]).items():
+        materialize_domains = set(LORA_DOMAINS) if getattr(self, "enforce_eager", True) else set()
+        for domain, lora_context in self._build_lora_contexts(
+            seqs,
+            [1 for _ in seqs],
+            materialize_domains=materialize_domains,
+        ).items():
             set_lora_context(lora_context, domain=domain)
         return positions
 
@@ -770,7 +806,10 @@ class BaseModelRunner:
         )
         total_size = sum(sizes)
         packed = torch.empty(total_size, dtype=torch.int32)
-        host_staging = torch.empty(total_size, dtype=torch.int32, device="cpu", pin_memory=True)
+        is_cuda_buffer = packed.device.type == "cuda"
+        host_staging = (
+            torch.empty(total_size, dtype=torch.int32, device="cpu", pin_memory=True) if is_cuda_buffer else packed
+        )
         offsets = [0]
         for size in sizes:
             offsets.append(offsets[-1] + size)
@@ -793,23 +832,29 @@ class BaseModelRunner:
         host_active_slot_ids.copy_(torch.arange(-1, max_lora_buckets - 1, dtype=torch.int32))
         host_num_tokens.zero_()
         host_slot_offsets.zero_()
-        packed.copy_(host_staging, non_blocking=True)
-        return {
+
+        buffers = {
             "packed": packed,
-            "host_staging": host_staging,
-            "copy_event": torch.cuda.Event(),
-            "copy_pending": False,
             "token_to_slot": token_to_slot,
             "token_indices_sorted_by_slot": token_indices,
             "active_slot_ids": active_slot_ids,
             "num_tokens_per_slot": num_tokens,
             "slot_start_offsets": slot_offsets,
-            "host_token_to_slot": host_token_to_slot,
-            "host_token_indices_sorted_by_slot": host_token_indices,
-            "host_active_slot_ids": host_active_slot_ids,
-            "host_num_tokens_per_slot": host_num_tokens,
-            "host_slot_start_offsets": host_slot_offsets,
         }
+        if is_cuda_buffer:
+            buffers.update(
+                {
+                    "host_staging": host_staging,
+                    "copy_event": torch.cuda.Event(),
+                    "copy_pending": False,
+                    "host_token_to_slot": host_token_to_slot,
+                    "host_token_indices_sorted_by_slot": host_token_indices,
+                    "host_active_slot_ids": host_active_slot_ids,
+                    "host_num_tokens_per_slot": host_num_tokens,
+                    "host_slot_start_offsets": host_slot_offsets,
+                }
+            )
+        return buffers
 
     def _copy_lora_domain_to_graph_vars(
         self,
@@ -836,7 +881,7 @@ class BaseModelRunner:
         num_tokens_buf: torch.Tensor = domain_vars["num_tokens_per_slot"]
         slot_start_buf: torch.Tensor = domain_vars["slot_start_offsets"]
 
-        token_count = 0 if context.token_to_slot is None else context.token_to_slot.size(0)
+        token_count = context.token_count
         has_host_metadata = context.host_token_to_slot is not None
         if "host_staging" in domain_vars and (context.no_lora_flag or has_host_metadata):
             if domain_vars["copy_pending"]:
@@ -915,7 +960,7 @@ class BaseModelRunner:
     def _set_graph_lora_context(self, graph_vars: dict, domain: str, context: LoRAContext) -> None:
         self._copy_lora_domain_to_graph_vars(graph_vars, domain, context)
         domain_vars = graph_vars["lora_domains"][domain]
-        token_count = 0 if context.token_to_slot is None else context.token_to_slot.size(0)
+        token_count = context.token_count
         num_lora_buckets = domain_vars["active_slot_ids"].size(0)
         set_lora_context(
             LoRAContext(
@@ -933,6 +978,12 @@ class BaseModelRunner:
     def _set_graph_lora_contexts(self, graph_vars: dict, contexts: dict[str, LoRAContext]) -> None:
         for domain in LORA_DOMAINS:
             self._set_graph_lora_context(graph_vars, domain, contexts[domain])
+
+    def _materialize_lora_contexts(self, contexts: dict[str, LoRAContext]) -> None:
+        for domain, context in contexts.items():
+            materialized = materialize_lora_context(context)
+            contexts[domain] = materialized
+            set_lora_context(materialized, domain=domain)
 
     @torch.inference_mode()
     def capture_cudagraph(self):
@@ -1108,9 +1159,11 @@ class BaseModelRunner:
         dit_context = lora_contexts[DIT_LORA_DOMAIN]
 
         def run_diffusion_eager():
+            eager_dit_context = materialize_lora_context(dit_context)
+            set_lora_context(eager_dit_context, domain=DIT_LORA_DOMAIN)
             sequence_length = self._dit_lora_sequence_length()
-            token_to_slot = dit_context.token_to_slot
-            if not dit_context.no_lora_flag and token_to_slot is not None and sequence_length > 0:
+            token_to_slot = eager_dit_context.token_to_slot
+            if not eager_dit_context.no_lora_flag and token_to_slot is not None and sequence_length > 0:
                 rows_per_branch = token_to_slot.numel() // self.cfg_branches
                 padded_batch_size = rows_per_branch // sequence_length
                 if padded_batch_size > batch_size:
@@ -1132,11 +1185,7 @@ class BaseModelRunner:
         if batch_size > self.graph_bs[-1] or z_noise is None:
             return run_diffusion_eager()
 
-        has_active_dit_lora = (
-            not dit_context.no_lora_flag
-            and dit_context.token_to_slot is not None
-            and dit_context.token_to_slot.numel() > 0
-        )
+        has_active_dit_lora = not dit_context.no_lora_flag and dit_context.token_count > 0
         graph_kind = "lora" if has_active_dit_lora else "base"
         graphs = self.prefill_diffusion_graphs[graph_kind]
         if not graphs:
@@ -1159,7 +1208,7 @@ class BaseModelRunner:
     def run_model(self, inputs: dict, is_prefill: bool):
         lora_contexts = {domain: get_lora_context(domain) for domain in LORA_DOMAINS}
         has_active_lora = any(
-            not context.no_lora_flag and context.token_to_slot is not None for context in lora_contexts.values()
+            not context.no_lora_flag and context.token_count > 0 for context in lora_contexts.values()
         )
         has_lora_graph = has_active_lora and bool(getattr(self, "graphs", {}).get("lora"))
         try:
@@ -1176,6 +1225,7 @@ class BaseModelRunner:
                 or inputs["positions"].size(0) > 512
                 or (has_active_lora and not has_lora_graph)
             ):
+                self._materialize_lora_contexts(lora_contexts)
                 return self.model(**inputs)
 
             bs = inputs["positions"].size(0)

--- a/nanovllm_voxcpm/engine/model_runner.py
+++ b/nanovllm_voxcpm/engine/model_runner.py
@@ -1116,7 +1116,7 @@ class BaseModelRunner:
                 )
             },
         }
-        self.prefill_diffusion_graphs = {"base": {}, "lora": {}}
+        self.prefill_diffusion_graphs: dict[str, dict[int, torch.cuda.CUDAGraph]] = {"base": {}, "lora": {}}
         capture_lora_graphs = bool(
             self._config.lora_config is not None
             and getattr(self._config.lora_config, "enable_dit", False)
@@ -1154,7 +1154,10 @@ class BaseModelRunner:
         inputs: dict[str, torch.Tensor],
         lora_contexts: dict[str, LoRAContext],
     ):
-        diffusion_inputs, outputs = self.model.forward_backbone(**inputs)
+        forward_backbone = getattr(self.model, "forward_backbone", None)
+        if not callable(forward_backbone):
+            raise RuntimeError("diffusion graph replay requires model.forward_backbone")
+        diffusion_inputs, outputs = forward_backbone(**inputs)
         batch_size = diffusion_inputs["mu"].size(0)
         dit_context = lora_contexts[DIT_LORA_DOMAIN]
 

--- a/nanovllm_voxcpm/layers/audio_vae.py
+++ b/nanovllm_voxcpm/layers/audio_vae.py
@@ -347,8 +347,13 @@ class AudioVAE(nn.Module):
         """
         return self.decoder(z)
 
-    def streaming_decoder(self) -> BatchedStreamingVAEDecoder:
-        return BatchedStreamingVAEDecoder(self, CausalConv1d, CausalTransposeConv1d)
+    def streaming_decoder(self, max_batch_size: int | None = None) -> BatchedStreamingVAEDecoder:
+        return BatchedStreamingVAEDecoder(
+            self,
+            CausalConv1d,
+            CausalTransposeConv1d,
+            max_batch_size=max_batch_size,
+        )
 
     @torch.inference_mode()
     def encode(self, audio_data: torch.Tensor, sample_rate: int):

--- a/nanovllm_voxcpm/layers/audio_vae.py
+++ b/nanovllm_voxcpm/layers/audio_vae.py
@@ -7,6 +7,8 @@ from torch import nn
 import torch.nn.functional as F
 from torch.nn.utils import weight_norm
 
+from nanovllm_voxcpm.layers.streaming_vae import BatchedStreamingVAEDecoder
+
 
 def WNConv1d(*args, **kwargs):
     return weight_norm(nn.Conv1d(*args, **kwargs))
@@ -344,6 +346,9 @@ class AudioVAE(nn.Module):
                 Decoded audio data.
         """
         return self.decoder(z)
+
+    def streaming_decoder(self) -> BatchedStreamingVAEDecoder:
+        return BatchedStreamingVAEDecoder(self, CausalConv1d, CausalTransposeConv1d)
 
     @torch.inference_mode()
     def encode(self, audio_data: torch.Tensor, sample_rate: int):

--- a/nanovllm_voxcpm/layers/audio_vae_v2.py
+++ b/nanovllm_voxcpm/layers/audio_vae_v2.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel
 from torch import nn
 from torch.nn.utils import weight_norm
 
+from nanovllm_voxcpm.layers.streaming_vae import BatchedStreamingVAEDecoder
+
 
 def WNConv1d(*args, **kwargs):
     return weight_norm(nn.Conv1d(*args, **kwargs))
@@ -400,6 +402,9 @@ class AudioVAEV2(nn.Module):
     @torch.inference_mode()
     def decode(self, z: torch.Tensor, sr_cond: torch.Tensor | None = None):
         return self.decoder(z, sr_cond)
+
+    def streaming_decoder(self) -> BatchedStreamingVAEDecoder:
+        return BatchedStreamingVAEDecoder(self, CausalConv1d, CausalTransposeConv1d)
 
     @torch.inference_mode()
     def encode(self, audio_data: torch.Tensor, sample_rate: int):

--- a/nanovllm_voxcpm/layers/audio_vae_v2.py
+++ b/nanovllm_voxcpm/layers/audio_vae_v2.py
@@ -403,8 +403,13 @@ class AudioVAEV2(nn.Module):
     def decode(self, z: torch.Tensor, sr_cond: torch.Tensor | None = None):
         return self.decoder(z, sr_cond)
 
-    def streaming_decoder(self) -> BatchedStreamingVAEDecoder:
-        return BatchedStreamingVAEDecoder(self, CausalConv1d, CausalTransposeConv1d)
+    def streaming_decoder(self, max_batch_size: int | None = None) -> BatchedStreamingVAEDecoder:
+        return BatchedStreamingVAEDecoder(
+            self,
+            CausalConv1d,
+            CausalTransposeConv1d,
+            max_batch_size=max_batch_size,
+        )
 
     @torch.inference_mode()
     def encode(self, audio_data: torch.Tensor, sample_rate: int):

--- a/nanovllm_voxcpm/layers/streaming_vae.py
+++ b/nanovllm_voxcpm/layers/streaming_vae.py
@@ -12,14 +12,30 @@ class BatchedStreamingVAEDecoder:
         vae: nn.Module,
         causal_conv_type: type[nn.Conv1d],
         causal_transpose_conv_type: type[nn.ConvTranspose1d],
+        max_batch_size: int | None = None,
     ):
+        if max_batch_size is not None and max_batch_size < 1:
+            raise ValueError("max_batch_size must be positive")
         self._vae = vae
         self._causal_conv_type = causal_conv_type
         self._causal_transpose_conv_type = causal_transpose_conv_type
+        self._batch_size_buckets = self._make_batch_size_buckets(max_batch_size)
         self._states: dict[int, dict[Hashable, torch.Tensor]] = {}
         self._stream_ids: Sequence[Hashable] | None = None
         self._initialized_streams: set[Hashable] = set()
         self._install()
+
+    @staticmethod
+    def _make_batch_size_buckets(max_batch_size: int | None) -> tuple[int, ...]:
+        if max_batch_size is None:
+            return ()
+        buckets = []
+        batch_size = 1
+        while batch_size < max_batch_size:
+            buckets.append(batch_size)
+            batch_size *= 2
+        buckets.append(max_batch_size)
+        return tuple(buckets)
 
     @torch.inference_mode()
     def decode_chunks(
@@ -56,7 +72,7 @@ class BatchedStreamingVAEDecoder:
                     self._decode(context, [stream_id])
                 self._initialized_streams.add(stream_id)
 
-            return self._decode(z_chunks, stream_ids)
+            return self._decode_bucketed(z_chunks, stream_ids)
         except Exception:
             for layer_id, layer_states in self._states.items():
                 for stream_id, state in state_snapshot[layer_id].items():
@@ -67,6 +83,31 @@ class BatchedStreamingVAEDecoder:
             self._initialized_streams.difference_update(stream_ids)
             self._initialized_streams.update(initialized_snapshot)
             raise
+
+    @torch.inference_mode()
+    def warmup(self, latent_channels: int, chunk_size: int) -> None:
+        """Initialize decoder kernels for every configured batch-size bucket."""
+        if not self._batch_size_buckets:
+            return
+        if self._initialized_streams or any(self._states.values()):
+            raise RuntimeError("streaming VAE warmup requires empty stream state")
+
+        parameter = next(self._vae.decoder.parameters(), None)
+        if parameter is None:
+            raise RuntimeError("streaming VAE decoder has no parameters")
+        for batch_size in self._batch_size_buckets:
+            z_chunks = torch.zeros(
+                batch_size,
+                latent_channels,
+                chunk_size,
+                device=parameter.device,
+                dtype=parameter.dtype,
+            )
+            stream_ids = [object() for _ in range(batch_size)]
+            self.decode_chunks(z_chunks, stream_ids)
+            self.clear()
+        if parameter.device.type == "cuda":
+            torch.cuda.synchronize(parameter.device)
 
     def release(self, stream_id: Hashable) -> None:
         """Release all cached convolution state for a completed request."""
@@ -87,6 +128,28 @@ class BatchedStreamingVAEDecoder:
             return self._vae.decode(z_chunks)
         finally:
             self._stream_ids = None
+
+    def _decode_bucketed(self, z_chunks: torch.Tensor, stream_ids: Sequence[Hashable]) -> torch.Tensor:
+        batch_size = z_chunks.size(0)
+        padded_batch_size = next(
+            (bucket for bucket in self._batch_size_buckets if bucket >= batch_size),
+            batch_size,
+        )
+        if padded_batch_size == batch_size:
+            return self._decode(z_chunks, stream_ids)
+
+        num_padding = padded_batch_size - batch_size
+        padding = z_chunks.new_zeros((num_padding, *z_chunks.shape[1:]))
+        dummy_stream_ids = [object() for _ in range(num_padding)]
+        try:
+            output = self._decode(
+                torch.cat([z_chunks, padding], dim=0),
+                [*stream_ids, *dummy_stream_ids],
+            )
+            return output[:batch_size]
+        finally:
+            for stream_id in dummy_stream_ids:
+                self.release(stream_id)
 
     def _install(self) -> None:
         for module in self._vae.decoder.modules():

--- a/nanovllm_voxcpm/layers/streaming_vae.py
+++ b/nanovllm_voxcpm/layers/streaming_vae.py
@@ -1,0 +1,165 @@
+from collections.abc import Hashable, Sequence
+
+import torch
+from torch import nn
+
+
+class BatchedStreamingVAEDecoder:
+    """Stateful causal VAE decoder for dynamically batched request streams."""
+
+    def __init__(
+        self,
+        vae: nn.Module,
+        causal_conv_type: type[nn.Conv1d],
+        causal_transpose_conv_type: type[nn.ConvTranspose1d],
+    ):
+        self._vae = vae
+        self._causal_conv_type = causal_conv_type
+        self._causal_transpose_conv_type = causal_transpose_conv_type
+        self._states: dict[int, dict[Hashable, torch.Tensor]] = {}
+        self._stream_ids: Sequence[Hashable] | None = None
+        self._initialized_streams: set[Hashable] = set()
+        self._install()
+
+    @torch.inference_mode()
+    def decode_chunks(
+        self,
+        z_chunks: torch.Tensor,
+        stream_ids: Sequence[Hashable],
+        initial_contexts: Sequence[torch.Tensor | None] | None = None,
+    ) -> torch.Tensor:
+        """Decode one new latent chunk for each stream in a dynamic batch."""
+        if z_chunks.ndim != 3:
+            raise ValueError(f"z_chunks must have shape [B, D, T], got {tuple(z_chunks.shape)}")
+        if len(stream_ids) != z_chunks.size(0):
+            raise ValueError("stream_ids length must match z_chunks batch size")
+        if len(set(stream_ids)) != len(stream_ids):
+            raise ValueError("stream_ids must be unique within a decode batch")
+        if initial_contexts is None:
+            initial_contexts = [None] * len(stream_ids)
+        if len(initial_contexts) != len(stream_ids):
+            raise ValueError("initial_contexts length must match stream_ids length")
+
+        missing = object()
+        state_snapshot = {
+            layer_id: {stream_id: layer_states.get(stream_id, missing) for stream_id in stream_ids}
+            for layer_id, layer_states in self._states.items()
+        }
+        initialized_snapshot = {stream_id for stream_id in stream_ids if stream_id in self._initialized_streams}
+        try:
+            for stream_id, context in zip(stream_ids, initial_contexts):
+                if stream_id in self._initialized_streams:
+                    continue
+                if context is not None and context.numel() > 0:
+                    if context.ndim != 3 or context.size(0) != 1:
+                        raise ValueError("each initial context must have shape [1, D, T]")
+                    self._decode(context, [stream_id])
+                self._initialized_streams.add(stream_id)
+
+            return self._decode(z_chunks, stream_ids)
+        except Exception:
+            for layer_id, layer_states in self._states.items():
+                for stream_id, state in state_snapshot[layer_id].items():
+                    if state is missing:
+                        layer_states.pop(stream_id, None)
+                    else:
+                        layer_states[stream_id] = state
+            self._initialized_streams.difference_update(stream_ids)
+            self._initialized_streams.update(initialized_snapshot)
+            raise
+
+    def release(self, stream_id: Hashable) -> None:
+        """Release all cached convolution state for a completed request."""
+        self._initialized_streams.discard(stream_id)
+        for layer_states in self._states.values():
+            layer_states.pop(stream_id, None)
+
+    def clear(self) -> None:
+        self._initialized_streams.clear()
+        for layer_states in self._states.values():
+            layer_states.clear()
+
+    def _decode(self, z_chunks: torch.Tensor, stream_ids: Sequence[Hashable]) -> torch.Tensor:
+        if self._stream_ids is not None:
+            raise RuntimeError("Streaming VAE decode is not reentrant")
+        self._stream_ids = stream_ids
+        try:
+            return self._vae.decode(z_chunks)
+        finally:
+            self._stream_ids = None
+
+    def _install(self) -> None:
+        for module in self._vae.decoder.modules():
+            if isinstance(module, self._causal_conv_type):
+                padding = module._CausalConv1d__padding * 2 - getattr(
+                    module,
+                    "_CausalConv1d__output_padding",
+                    0,
+                )
+                if padding > 0:
+                    self._patch_causal_conv(module, padding)
+            elif isinstance(module, self._causal_transpose_conv_type):
+                trim = module._CausalTransposeConv1d__padding * 2 - module._CausalTransposeConv1d__output_padding
+                context = module.kernel_size[0] // module.stride[0] - 1
+                if context > 0:
+                    self._patch_transpose_conv(module, context, trim)
+
+    def _current_stream_ids(self, batch_size: int) -> Sequence[Hashable]:
+        if self._stream_ids is None or len(self._stream_ids) != batch_size:
+            raise RuntimeError("Causal VAE layer executed outside decode_chunks")
+        return self._stream_ids
+
+    def _patch_causal_conv(self, module: nn.Conv1d, padding: int) -> None:
+        layer_states = self._states.setdefault(id(module), {})
+
+        def forward(x: torch.Tensor, *, _module=module, _padding=padding, _states=layer_states):
+            if self._stream_ids is None:
+                return type(_module).forward(_module, x)
+            stream_ids = self._current_stream_ids(x.size(0))
+            contexts = []
+            for index, stream_id in enumerate(stream_ids):
+                state = _states.get(stream_id)
+                if state is None:
+                    state = torch.zeros(
+                        x.size(1),
+                        _padding,
+                        device=x.device,
+                        dtype=x.dtype,
+                    )
+                contexts.append(state)
+                combined = torch.cat([state, x[index]], dim=-1)
+                _states[stream_id] = combined[:, -_padding:].detach()
+            padded = torch.cat([torch.stack(contexts, dim=0), x], dim=-1)
+            return nn.Conv1d.forward(_module, padded)
+
+        module.forward = forward
+
+    def _patch_transpose_conv(self, module: nn.ConvTranspose1d, context: int, trim: int) -> None:
+        layer_states = self._states.setdefault(id(module), {})
+
+        def forward(x: torch.Tensor, *, _module=module, _context=context, _trim=trim, _states=layer_states):
+            if self._stream_ids is None:
+                return type(_module).forward(_module, x)
+            stream_ids = self._current_stream_ids(x.size(0))
+            contexts = []
+            for index, stream_id in enumerate(stream_ids):
+                state = _states.get(stream_id)
+                if state is None:
+                    state = torch.zeros(
+                        x.size(1),
+                        _context,
+                        device=x.device,
+                        dtype=x.dtype,
+                    )
+                contexts.append(state)
+                combined = torch.cat([state, x[index]], dim=-1)
+                _states[stream_id] = combined[:, -_context:].detach()
+            full_input = torch.cat([torch.stack(contexts, dim=0), x], dim=-1)
+            output = nn.ConvTranspose1d.forward(_module, full_input)
+            left = _context * _module.stride[0]
+            return output[..., left:-_trim] if _trim > 0 else output[..., left:]
+
+        module.forward = forward
+
+
+__all__ = ["BatchedStreamingVAEDecoder"]

--- a/nanovllm_voxcpm/models/voxcpm/engine.py
+++ b/nanovllm_voxcpm/models/voxcpm/engine.py
@@ -77,6 +77,7 @@ class VoxCPMEngine(LLMEngineBase):
                     seed_step=seq.custom_payload.seed_step,
                 ),
                 adapter_id=seq.adapter_id,
+                seq_id=seq.seq_id,
             )
         else:
             return RunnerTask(
@@ -95,6 +96,7 @@ class VoxCPMEngine(LLMEngineBase):
                     seed_step=seq.custom_payload.seed_step,
                 ),
                 adapter_id=seq.adapter_id,
+                seq_id=seq.seq_id,
             )
 
     def postprocess_seq(self, seq: Sequence[VoxCPMSeqPayload], outputs: dict, is_prefill: bool):

--- a/nanovllm_voxcpm/models/voxcpm/model.py
+++ b/nanovllm_voxcpm/models/voxcpm/model.py
@@ -839,7 +839,7 @@ class VoxCPMModel(nn.Module):
         self.stop_actn = nn.SiLU()
         self.stop_head = nn.Linear(config.lm_config.hidden_size, 2, bias=False)
 
-    def forward(
+    def forward_backbone(
         self,
         positions: torch.Tensor,
         text_tokens: torch.Tensor,
@@ -896,17 +896,62 @@ class VoxCPMModel(nn.Module):
         dit_hidden = dit_hidden_1 + dit_hidden_2  # [b, h_dit]
 
         # (b, P, D)
-        pred_feat = self.feat_decoder(
-            mu=dit_hidden,
-            cond=prefix_feat_cond.transpose(1, 2).contiguous(),
+        stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(dim=-1)
+
+        return (
+            {
+                "mu": dit_hidden,
+                "cond": prefix_feat_cond.transpose(1, 2).contiguous(),
+                "temperature": temperature,
+                "cfg_value": cfg_value,
+                "z_noise": z_noise,
+            },
+            {"stop_flag": stop_flag},
+        )
+
+    def forward_diffusion(
+        self,
+        mu: torch.Tensor,
+        cond: torch.Tensor,
+        temperature: torch.Tensor,
+        cfg_value: torch.Tensor,
+        z_noise: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.feat_decoder(
+            mu=mu,
+            cond=cond,
             temperature=temperature,
             cfg_value=cfg_value,
             z_noise=z_noise,
         ).transpose(1, 2)
 
-        stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(dim=-1)
-
+    def make_dummy_diffusion_inputs(self, batch_size: int) -> dict[str, torch.Tensor]:
         return {
-            "latents": pred_feat,
-            "stop_flag": stop_flag,
+            "mu": torch.zeros(batch_size, self.config.dit_config.hidden_dim),
+            "cond": torch.zeros(batch_size, self.feat_dim, self.patch_size),
+            "temperature": torch.zeros(batch_size),
+            "cfg_value": torch.zeros(batch_size),
+            "z_noise": torch.zeros(batch_size, self.feat_dim, self.patch_size),
         }
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        text_tokens: torch.Tensor,
+        feat: torch.Tensor,
+        feat_mask: torch.Tensor,
+        temperature: torch.Tensor,
+        cfg_value: torch.Tensor,
+        z_noise: torch.Tensor | None = None,
+    ):
+        diffusion_inputs, outputs = self.forward_backbone(
+            positions=positions,
+            text_tokens=text_tokens,
+            feat=feat,
+            feat_mask=feat_mask,
+            temperature=temperature,
+            cfg_value=cfg_value,
+            z_noise=z_noise,
+        )
+        outputs["latents"] = self.forward_diffusion(**diffusion_inputs)
+        return outputs

--- a/nanovllm_voxcpm/models/voxcpm/runner.py
+++ b/nanovllm_voxcpm/models/voxcpm/runner.py
@@ -72,7 +72,8 @@ class VoxCPMRunner(BaseModelRunner):
 
         vae_state_dict = torch.load(os.path.join(model_path, "audiovae.pth"))["state_dict"]
         self.vae.load_state_dict(vae_state_dict)
-        self.vae_streaming_decoder = self.vae.streaming_decoder()
+        self.vae_streaming_decoder = self.vae.streaming_decoder(self._config.max_num_seqs)
+        self.vae_streaming_decoder.warmup(self.feat_dim, self.patch_size)
         torch.set_default_dtype(torch.bfloat16)
 
     def make_dummy_inputs(self, batch_size: int, length: int) -> dict[str, torch.Tensor]:

--- a/nanovllm_voxcpm/models/voxcpm/runner.py
+++ b/nanovllm_voxcpm/models/voxcpm/runner.py
@@ -72,6 +72,7 @@ class VoxCPMRunner(BaseModelRunner):
 
         vae_state_dict = torch.load(os.path.join(model_path, "audiovae.pth"))["state_dict"]
         self.vae.load_state_dict(vae_state_dict)
+        self.vae_streaming_decoder = self.vae.streaming_decoder()
         torch.set_default_dtype(torch.bfloat16)
 
     def make_dummy_inputs(self, batch_size: int, length: int) -> dict[str, torch.Tensor]:
@@ -151,21 +152,49 @@ class VoxCPMRunner(BaseModelRunner):
         outputs = self.run_model(inputs, is_prefill)
         latents = outputs["latents"]
 
-        pad_lengths = compute_pad_lengths(seqs)
-        max_pad_decode = max(pad_lengths) + self.patch_size
-
-        vae_decoder_inputs = torch.zeros(len(seqs), max_pad_decode, self.feat_dim, dtype=torch.float32, device="cuda")
-        for i in range(len(seqs)):
-            pad_len = pad_lengths[i]
-            if pad_len > 0:
-                vae_decoder_inputs[i, :pad_len] = torch.from_numpy(seqs[i].custom_payload.padding_decode).cuda(
-                    non_blocking=True
+        if all(getattr(seq, "seq_id", None) is not None for seq in seqs):
+            initial_contexts = []
+            for seq in seqs:
+                padding_decode = seq.custom_payload.padding_decode
+                initial_contexts.append(
+                    None
+                    if padding_decode is None
+                    else torch.from_numpy(padding_decode)
+                    .to(device="cuda", dtype=torch.float32, non_blocking=True)
+                    .transpose(0, 1)
+                    .unsqueeze(0)
                 )
-            vae_decoder_inputs[i, pad_len : pad_len + self.patch_size] = latents[i].to(torch.float32)
+            vae_decoder_outputs = (
+                self.vae_streaming_decoder.decode_chunks(
+                    latents.to(torch.float32).permute(0, 2, 1),
+                    [seq.seq_id for seq in seqs],
+                    initial_contexts,
+                )[:, 0, :]
+                .cpu()
+                .numpy()
+            )
+            ret_waveforms = [vae_decoder_outputs[i] for i in range(len(seqs))]
+        else:
+            pad_lengths = compute_pad_lengths(seqs)
+            max_pad_decode = max(pad_lengths) + self.patch_size
+            vae_decoder_inputs = torch.zeros(
+                len(seqs),
+                max_pad_decode,
+                self.feat_dim,
+                dtype=torch.float32,
+                device="cuda",
+            )
+            for i in range(len(seqs)):
+                pad_len = pad_lengths[i]
+                if pad_len > 0:
+                    vae_decoder_inputs[i, :pad_len] = torch.from_numpy(seqs[i].custom_payload.padding_decode).cuda(
+                        non_blocking=True
+                    )
+                vae_decoder_inputs[i, pad_len : pad_len + self.patch_size] = latents[i].to(torch.float32)
+            vae_decoder_outputs = self.vae.decode(vae_decoder_inputs.permute(0, 2, 1))[:, 0, :].cpu().numpy()
+            ret_waveforms = slice_waveforms(vae_decoder_outputs, pad_lengths, self.patch_size, self.vae.chunk_size)
 
-        vae_decoder_outputs = self.vae.decode(vae_decoder_inputs.permute(0, 2, 1))[:, 0, :].cpu().numpy()
         stop_flags = outputs["stop_flag"].cpu().tolist()
-        ret_waveforms = slice_waveforms(vae_decoder_outputs, pad_lengths, self.patch_size, self.vae.chunk_size)
         np_latents = latents.to(torch.float32).cpu().numpy()
 
         return assemble_run_outputs(np_latents, stop_flags, ret_waveforms)

--- a/nanovllm_voxcpm/models/voxcpm2/engine.py
+++ b/nanovllm_voxcpm/models/voxcpm2/engine.py
@@ -67,6 +67,7 @@ class VoxCPM2Engine(LLMEngineBase):
                     seed_step=seq.custom_payload.seed_step,
                 ),
                 adapter_id=seq.adapter_id,
+                seq_id=seq.seq_id,
             )
 
         return RunnerTask(
@@ -85,6 +86,7 @@ class VoxCPM2Engine(LLMEngineBase):
                 seed_step=seq.custom_payload.seed_step,
             ),
             adapter_id=seq.adapter_id,
+            seq_id=seq.seq_id,
         )
 
     def postprocess_seq(self, seq: Sequence[VoxCPM2SeqPayload], outputs: dict, is_prefill: bool):

--- a/nanovllm_voxcpm/models/voxcpm2/model.py
+++ b/nanovllm_voxcpm/models/voxcpm2/model.py
@@ -601,7 +601,7 @@ class VoxCPM2Model(nn.Module):
         self.stop_actn = nn.SiLU()
         self.stop_head = nn.Linear(config.lm_config.hidden_size, 2, bias=False)
 
-    def forward(
+    def forward_backbone(
         self,
         positions: torch.Tensor,
         text_tokens: torch.Tensor,
@@ -638,12 +638,61 @@ class VoxCPM2Model(nn.Module):
             prefix_feat_cond = feat
 
         dit_hidden = torch.cat([self.lm_to_dit_proj(lm_hidden), self.res_to_dit_proj(ralm_hidden)], dim=-1)
-        pred_feat = self.feat_decoder(
-            mu=dit_hidden,
-            cond=prefix_feat_cond.transpose(1, 2).contiguous(),
+        stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(dim=-1)
+        return (
+            {
+                "mu": dit_hidden,
+                "cond": prefix_feat_cond.transpose(1, 2).contiguous(),
+                "temperature": temperature,
+                "cfg_value": cfg_value,
+                "z_noise": z_noise,
+            },
+            {"stop_flag": stop_flag},
+        )
+
+    def forward_diffusion(
+        self,
+        mu: torch.Tensor,
+        cond: torch.Tensor,
+        temperature: torch.Tensor,
+        cfg_value: torch.Tensor,
+        z_noise: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.feat_decoder(
+            mu=mu,
+            cond=cond,
             temperature=temperature,
             cfg_value=cfg_value,
             z_noise=z_noise,
         ).transpose(1, 2)
-        stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(dim=-1)
-        return {"latents": pred_feat, "stop_flag": stop_flag}
+
+    def make_dummy_diffusion_inputs(self, batch_size: int) -> dict[str, torch.Tensor]:
+        return {
+            "mu": torch.zeros(batch_size, 2 * self.config.dit_config.hidden_dim),
+            "cond": torch.zeros(batch_size, self.feat_dim, self.patch_size),
+            "temperature": torch.zeros(batch_size),
+            "cfg_value": torch.zeros(batch_size),
+            "z_noise": torch.zeros(batch_size, self.feat_dim, self.patch_size),
+        }
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        text_tokens: torch.Tensor,
+        feat: torch.Tensor,
+        feat_mask: torch.Tensor,
+        temperature: torch.Tensor,
+        cfg_value: torch.Tensor,
+        z_noise: torch.Tensor | None = None,
+    ):
+        diffusion_inputs, outputs = self.forward_backbone(
+            positions=positions,
+            text_tokens=text_tokens,
+            feat=feat,
+            feat_mask=feat_mask,
+            temperature=temperature,
+            cfg_value=cfg_value,
+            z_noise=z_noise,
+        )
+        outputs["latents"] = self.forward_diffusion(**diffusion_inputs)
+        return outputs

--- a/nanovllm_voxcpm/models/voxcpm2/runner.py
+++ b/nanovllm_voxcpm/models/voxcpm2/runner.py
@@ -56,6 +56,7 @@ class VoxCPM2Runner(BaseModelRunner):
         self.vae = AudioVAEV2(config=model_config.audio_vae_config)
         vae_state_dict = torch.load(os.path.join(model_path, "audiovae.pth"))["state_dict"]
         self.vae.load_state_dict(vae_state_dict)
+        self.vae_streaming_decoder = self.vae.streaming_decoder()
         torch.set_default_dtype(torch.bfloat16)
 
     def make_dummy_inputs(self, batch_size: int, length: int) -> dict[str, torch.Tensor]:
@@ -137,31 +138,61 @@ class VoxCPM2Runner(BaseModelRunner):
         outputs = self.run_model(inputs, is_prefill)
         latents = outputs["latents"]
 
-        pad_lengths = [
-            seq.custom_payload.padding_decode.shape[0] if seq.custom_payload.padding_decode is not None else 0
-            for seq in seqs
-        ]
-
-        max_pad_decode = max(pad_lengths) + self.patch_size
-        vae_decoder_inputs = torch.zeros(len(seqs), max_pad_decode, self.feat_dim, dtype=torch.float32, device="cuda")
-        for i, seq in enumerate(seqs):
-            pad_len = pad_lengths[i]
-            if pad_len > 0:
-                vae_decoder_inputs[i, :pad_len] = torch.from_numpy(seq.custom_payload.padding_decode).cuda(
-                    non_blocking=True
+        if all(getattr(seq, "seq_id", None) is not None for seq in seqs):
+            initial_contexts = []
+            for seq in seqs:
+                padding_decode = seq.custom_payload.padding_decode
+                initial_contexts.append(
+                    None
+                    if padding_decode is None
+                    else torch.from_numpy(padding_decode)
+                    .to(device="cuda", dtype=torch.float32, non_blocking=True)
+                    .transpose(0, 1)
+                    .unsqueeze(0)
                 )
-            vae_decoder_inputs[i, pad_len : pad_len + self.patch_size] = latents[i].to(torch.float32)
-
-        vae_decoder_outputs = self.vae.decode(vae_decoder_inputs.permute(0, 2, 1))[:, 0, :].cpu().numpy()
-        stop_flag = outputs["stop_flag"].cpu().tolist()
-        ret_waveforms = []
-        for i, pad_len in enumerate(pad_lengths):
-            ret_waveforms.append(
-                vae_decoder_outputs[
-                    i,
-                    pad_len * self.vae.decoder_chunk_size : (pad_len + self.patch_size) * self.vae.decoder_chunk_size,
-                ]
+            vae_decoder_outputs = (
+                self.vae_streaming_decoder.decode_chunks(
+                    latents.to(torch.float32).permute(0, 2, 1),
+                    [seq.seq_id for seq in seqs],
+                    initial_contexts,
+                )[:, 0, :]
+                .cpu()
+                .numpy()
             )
+            ret_waveforms = [vae_decoder_outputs[i] for i in range(len(seqs))]
+        else:
+            pad_lengths = [
+                seq.custom_payload.padding_decode.shape[0] if seq.custom_payload.padding_decode is not None else 0
+                for seq in seqs
+            ]
+            max_pad_decode = max(pad_lengths) + self.patch_size
+            vae_decoder_inputs = torch.zeros(
+                len(seqs),
+                max_pad_decode,
+                self.feat_dim,
+                dtype=torch.float32,
+                device="cuda",
+            )
+            for i, seq in enumerate(seqs):
+                pad_len = pad_lengths[i]
+                if pad_len > 0:
+                    vae_decoder_inputs[i, :pad_len] = torch.from_numpy(seq.custom_payload.padding_decode).cuda(
+                        non_blocking=True
+                    )
+                vae_decoder_inputs[i, pad_len : pad_len + self.patch_size] = latents[i].to(torch.float32)
+            vae_decoder_outputs = self.vae.decode(vae_decoder_inputs.permute(0, 2, 1))[:, 0, :].cpu().numpy()
+            ret_waveforms = []
+            for i, pad_len in enumerate(pad_lengths):
+                ret_waveforms.append(
+                    vae_decoder_outputs[
+                        i,
+                        pad_len
+                        * self.vae.decoder_chunk_size : (pad_len + self.patch_size)
+                        * self.vae.decoder_chunk_size,
+                    ]
+                )
+
+        stop_flag = outputs["stop_flag"].cpu().tolist()
 
         np_latents = latents.to(torch.float32).cpu().numpy()
         return [

--- a/nanovllm_voxcpm/models/voxcpm2/runner.py
+++ b/nanovllm_voxcpm/models/voxcpm2/runner.py
@@ -59,7 +59,8 @@ class VoxCPM2Runner(BaseModelRunner):
         vae_state_dict = torch.load(os.path.join(model_path, "audiovae.pth"))["state_dict"]
         self.vae.load_state_dict(vae_state_dict)
         self._prepare_vae_decoder_for_inference()
-        self.vae_streaming_decoder = self.vae.streaming_decoder()
+        self.vae_streaming_decoder = self.vae.streaming_decoder(self._config.max_num_seqs)
+        self.vae_streaming_decoder.warmup(self.feat_dim, self.patch_size)
         torch.set_default_dtype(torch.bfloat16)
 
     def _prepare_vae_decoder_for_inference(self) -> None:

--- a/nanovllm_voxcpm/models/voxcpm2/runner.py
+++ b/nanovllm_voxcpm/models/voxcpm2/runner.py
@@ -4,6 +4,7 @@ from multiprocessing.synchronize import Event
 
 import numpy as np
 import torch
+from torch.nn.utils import remove_weight_norm
 
 from nanovllm_voxcpm.config import Config
 from nanovllm_voxcpm.engine.model_runner import BaseModelRunner, RunnerTask
@@ -29,6 +30,7 @@ class VoxCPM2Payload:
 class VoxCPM2Runner(BaseModelRunner):
     model: VoxCPM2Model
     dit_lora_seq_len_offset = 3
+    vae_dtype = torch.float16
 
     def __init__(
         self,
@@ -56,6 +58,10 @@ class VoxCPM2Runner(BaseModelRunner):
         self.vae = AudioVAEV2(config=model_config.audio_vae_config)
         vae_state_dict = torch.load(os.path.join(model_path, "audiovae.pth"))["state_dict"]
         self.vae.load_state_dict(vae_state_dict)
+        for module in self.vae.decoder.modules():
+            if hasattr(module, "weight_g"):
+                remove_weight_norm(module)
+        self.vae.decoder.to(dtype=self.vae_dtype)
         self.vae_streaming_decoder = self.vae.streaming_decoder()
         torch.set_default_dtype(torch.bfloat16)
 
@@ -146,16 +152,17 @@ class VoxCPM2Runner(BaseModelRunner):
                     None
                     if padding_decode is None
                     else torch.from_numpy(padding_decode)
-                    .to(device="cuda", dtype=torch.float32, non_blocking=True)
+                    .to(device="cuda", dtype=self.vae_dtype, non_blocking=True)
                     .transpose(0, 1)
                     .unsqueeze(0)
                 )
             vae_decoder_outputs = (
                 self.vae_streaming_decoder.decode_chunks(
-                    latents.to(torch.float32).permute(0, 2, 1),
+                    latents.to(self.vae_dtype).permute(0, 2, 1),
                     [seq.seq_id for seq in seqs],
                     initial_contexts,
                 )[:, 0, :]
+                .to(torch.float32)
                 .cpu()
                 .numpy()
             )
@@ -170,7 +177,7 @@ class VoxCPM2Runner(BaseModelRunner):
                 len(seqs),
                 max_pad_decode,
                 self.feat_dim,
-                dtype=torch.float32,
+                dtype=self.vae_dtype,
                 device="cuda",
             )
             for i, seq in enumerate(seqs):
@@ -179,8 +186,11 @@ class VoxCPM2Runner(BaseModelRunner):
                     vae_decoder_inputs[i, :pad_len] = torch.from_numpy(seq.custom_payload.padding_decode).cuda(
                         non_blocking=True
                     )
-                vae_decoder_inputs[i, pad_len : pad_len + self.patch_size] = latents[i].to(torch.float32)
-            vae_decoder_outputs = self.vae.decode(vae_decoder_inputs.permute(0, 2, 1))[:, 0, :].cpu().numpy()
+                vae_decoder_inputs[i, pad_len : pad_len + self.patch_size] = latents[i].to(self.vae_dtype)
+            vae_decoder_outputs = self.vae.decode(vae_decoder_inputs.permute(0, 2, 1))[:, 0, :]
+            if isinstance(vae_decoder_outputs, torch.Tensor):
+                vae_decoder_outputs = vae_decoder_outputs.to(torch.float32)
+            vae_decoder_outputs = vae_decoder_outputs.cpu().numpy()
             ret_waveforms = []
             for i, pad_len in enumerate(pad_lengths):
                 ret_waveforms.append(

--- a/nanovllm_voxcpm/models/voxcpm2/runner.py
+++ b/nanovllm_voxcpm/models/voxcpm2/runner.py
@@ -58,12 +58,16 @@ class VoxCPM2Runner(BaseModelRunner):
         self.vae = AudioVAEV2(config=model_config.audio_vae_config)
         vae_state_dict = torch.load(os.path.join(model_path, "audiovae.pth"))["state_dict"]
         self.vae.load_state_dict(vae_state_dict)
+        self._prepare_vae_decoder_for_inference()
+        self.vae_streaming_decoder = self.vae.streaming_decoder()
+        torch.set_default_dtype(torch.bfloat16)
+
+    def _prepare_vae_decoder_for_inference(self) -> None:
+        """Fold weight norm and cast only the inference decoder to FP16."""
         for module in self.vae.decoder.modules():
             if hasattr(module, "weight_g"):
                 remove_weight_norm(module)
         self.vae.decoder.to(dtype=self.vae_dtype)
-        self.vae_streaming_decoder = self.vae.streaming_decoder()
-        torch.set_default_dtype(torch.bfloat16)
 
     def make_dummy_inputs(self, batch_size: int, length: int) -> dict[str, torch.Tensor]:
         return {

--- a/nanovllm_voxcpm/utils/context.py
+++ b/nanovllm_voxcpm/utils/context.py
@@ -27,6 +27,10 @@ class LoRAContext:
     slot_start_offsets: torch.Tensor | None = None
     no_lora_flag: bool = True
     num_active_loras: int = 0
+    host_token_to_slot: list[int] | None = None
+    host_token_indices_sorted_by_slot: list[int] | None = None
+    host_active_slot_ids: list[int] | None = None
+    host_num_tokens_per_slot: list[int] | None = None
     # Cached `LoRAMetadata` view of this context. Layers all build an identical
     # metadata object from the same context per step; we materialize it lazily
     # once per context instance and reuse across every LoRA-enabled layer in

--- a/nanovllm_voxcpm/utils/context.py
+++ b/nanovllm_voxcpm/utils/context.py
@@ -37,6 +37,12 @@ class LoRAContext:
     # the model. Cleared by ``set_lora_context`` (i.e. fresh each step).
     _cached_metadata: object | None = field(default=None, repr=False, compare=False)
 
+    @property
+    def token_count(self) -> int:
+        if self.token_to_slot is not None:
+            return self.token_to_slot.numel()
+        return len(self.host_token_to_slot or ())
+
 
 @dataclass
 class LoRAContexts:

--- a/tests/unit/test_calibrate_waveform.py
+++ b/tests/unit/test_calibrate_waveform.py
@@ -1,0 +1,50 @@
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_MODULE_PATH = Path(__file__).parents[2] / "benchmark" / "calibrate_waveform.py"
+_SPEC = importlib.util.spec_from_file_location("calibrate_waveform", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+compare_waveforms = _MODULE.compare_waveforms
+comparison_failures = _MODULE.comparison_failures
+
+
+def test_compare_waveforms_rejects_empty_inputs():
+    with pytest.raises(ValueError, match="non-empty"):
+        compare_waveforms(np.empty(0, dtype=np.float32), np.ones(1, dtype=np.float32))
+
+
+def test_compare_waveforms_does_not_treat_different_constants_as_correlated():
+    comparison = compare_waveforms(
+        np.ones(4, dtype=np.float32),
+        np.zeros(4, dtype=np.float32),
+    )
+
+    assert comparison["correlation"] == 0.0
+    assert comparison["rmse"] == 1.0
+    assert comparison["length_match"] is True
+
+
+def test_comparison_failures_enforces_lengths_and_thresholds():
+    comparison = compare_waveforms(
+        np.array([0.0, 1.0, 4.0, 9.0], dtype=np.float32),
+        np.array([0.0, 1.0, 2.0], dtype=np.float32),
+    )
+
+    failures = comparison_failures(
+        comparison,
+        require_same_length=True,
+        max_rmse=0.01,
+        max_abs_error=0.05,
+        min_correlation=0.9999,
+    )
+
+    assert any("sample count mismatch" in failure for failure in failures)
+    assert any("rmse" in failure for failure in failures)
+    assert any("max_abs_error" in failure for failure in failures)
+    assert any("correlation" in failure for failure in failures)

--- a/tests/unit/test_llm_engine.py
+++ b/tests/unit/test_llm_engine.py
@@ -134,6 +134,9 @@ def test_engine_step_finishes_sequence_and_supports_cancel(monkeypatch, tmp_path
     assert "lora_on_sequence_enqueued" in runner_calls
     assert "lora_on_sequence_started" in runner_calls
     assert "lora_on_sequence_finished" in runner_calls
+    assert runner_calls.count("release_sequence_state") == 2
+    release_calls = [args for name, args in _DummyRunner.instances[0].calls if name == "release_sequence_state"]
+    assert release_calls == [("cancelled",), ("seq-1",)]
 
 
 def test_engine_registers_and_unregisters_lora(monkeypatch, tmp_path):

--- a/tests/unit/test_lora_manager.py
+++ b/tests/unit/test_lora_manager.py
@@ -166,3 +166,47 @@ def test_lora_manager_validates_max_lora_rank_on_register():
             manager.register_lora("too-big", oversized_payload)
     finally:
         set_backend_for_testing(None)
+
+
+def test_lora_context_can_defer_device_metadata_for_graph_replay(monkeypatch):
+    import nanovllm_voxcpm.engine.lora_manager as lora_manager
+
+    plan = lora_manager.build_lora_batch_plan_from_token_to_slot(
+        adapter_to_slot={7: 0},
+        token_to_slot=[0, -1, 0],
+    )
+    monkeypatch.setattr(
+        lora_manager,
+        "_pack_int_tensors_to_cuda",
+        lambda *args: (_ for _ in ()).throw(AssertionError("device metadata should be deferred")),
+    )
+
+    context = lora_manager.build_lora_context_from_batch_plan(plan, materialize_device=False)
+
+    assert context.token_to_slot is None
+    assert context.host_token_to_slot == [0, -1, 0]
+    assert context.token_count == 3
+    assert context.no_lora_flag is False
+
+
+def test_materialize_lora_context_builds_deferred_device_metadata(monkeypatch):
+    import nanovllm_voxcpm.engine.lora_manager as lora_manager
+
+    plan = lora_manager.build_lora_batch_plan_from_token_to_slot(
+        adapter_to_slot={7: 0},
+        token_to_slot=[0, -1, 0],
+    )
+    context = lora_manager.build_lora_context_from_batch_plan(plan, materialize_device=False)
+    monkeypatch.setattr(
+        lora_manager,
+        "_pack_int_tensors_to_cuda",
+        lambda *lists: [torch.tensor(values, dtype=torch.int32) for values in lists],
+    )
+
+    materialized = lora_manager.materialize_lora_context(context)
+
+    assert materialized.token_to_slot.tolist() == [0, -1, 0]
+    assert materialized.token_indices_sorted_by_slot.tolist() == [0, 2]
+    assert materialized.active_slot_ids.tolist() == [0]
+    assert materialized.num_tokens_per_slot.tolist() == [2]
+    assert materialized.slot_start_offsets.tolist() == [0, 2]

--- a/tests/unit/test_model_runner_extended.py
+++ b/tests/unit/test_model_runner_extended.py
@@ -1043,6 +1043,47 @@ def test_load_lora_slot_initializes_slot_modules_dict():
     assert runner._lora_slot_modules[0] == []
 
 
+def test_load_lora_slot_skips_first_clear_and_only_clears_removed_modules():
+    from types import SimpleNamespace
+
+    import nanovllm_voxcpm.engine.model_runner as model_runner
+
+    calls = []
+
+    class FakeTensor:
+        def to(self, **kwargs):
+            return self
+
+    class FakeModule:
+        def __init__(self, name):
+            self.name = name
+
+        def clear_slot_lora(self, slot_id):
+            calls.append(("clear", self.name, slot_id))
+
+        def set_slot_lora(self, **kwargs):
+            calls.append(("set", self.name, kwargs["slot_id"]))
+
+    modules = {name: FakeModule(name) for name in ("a", "b")}
+    runner = object.__new__(model_runner.BaseModelRunner)
+    runner._lora_model_modules_cache = modules
+    runner._lora_slot_modules = {}
+    module_payload = SimpleNamespace(
+        lora_a=FakeTensor(),
+        lora_b=FakeTensor(),
+        effective_rank=1,
+        scaling=1.0,
+    )
+
+    runner._load_lora_slot(0, SimpleNamespace(modules={"a": module_payload}))
+    assert calls == [("set", "a", 0)]
+
+    calls.clear()
+    runner._lora_slot_modules[0] = ["a", "b"]
+    runner._load_lora_slot(0, SimpleNamespace(modules={"a": module_payload}))
+    assert calls == [("clear", "b", 0), ("set", "a", 0)]
+
+
 def test_exit_single_rank_enforce_eager_skips_graphs(monkeypatch):
     import nanovllm_voxcpm.engine.model_runner as model_runner
 
@@ -1068,11 +1109,15 @@ def test_exit_single_rank_non_eager_deletes_graphs(monkeypatch):
     runner.enforce_eager = False
     runner.graphs = {"base": {}, "lora": {}}
     runner.graph_pool = object()
+    runner.prefill_diffusion_graphs = {"base": {}, "lora": {}}
+    runner.prefill_diffusion_graph_vars = {}
 
     runner.exit()
 
     assert not hasattr(runner, "graphs")
     assert not hasattr(runner, "graph_pool")
+    assert not hasattr(runner, "prefill_diffusion_graphs")
+    assert not hasattr(runner, "prefill_diffusion_graph_vars")
 
 
 def _make_domain_vars(max_rows: int, max_lora_buckets: int) -> dict:
@@ -1083,6 +1128,89 @@ def _make_domain_vars(max_rows: int, max_lora_buckets: int) -> dict:
         "num_tokens_per_slot": torch.zeros(max_lora_buckets, dtype=torch.int32),
         "slot_start_offsets": torch.zeros(max_lora_buckets + 1, dtype=torch.int32),
     }
+
+
+def _make_host_staged_domain_vars(max_rows: int, max_lora_buckets: int) -> dict:
+    sizes = [max_rows, max_rows, max_lora_buckets, max_lora_buckets, max_lora_buckets + 1]
+    offsets = [0]
+    for size in sizes:
+        offsets.append(offsets[-1] + size)
+    packed = torch.empty(sum(sizes), dtype=torch.int32)
+    host = torch.empty_like(packed)
+
+    class FakeEvent:
+        def __init__(self):
+            self.recorded = 0
+            self.synchronized = 0
+
+        def record(self):
+            self.recorded += 1
+
+        def synchronize(self):
+            self.synchronized += 1
+
+    return {
+        "packed": packed,
+        "host_staging": host,
+        "copy_event": FakeEvent(),
+        "copy_pending": False,
+        "token_to_slot": packed[offsets[0] : offsets[1]],
+        "token_indices_sorted_by_slot": packed[offsets[1] : offsets[2]],
+        "active_slot_ids": packed[offsets[2] : offsets[3]],
+        "num_tokens_per_slot": packed[offsets[3] : offsets[4]],
+        "slot_start_offsets": packed[offsets[4] : offsets[5]],
+        "host_token_to_slot": host[offsets[0] : offsets[1]],
+        "host_token_indices_sorted_by_slot": host[offsets[1] : offsets[2]],
+        "host_active_slot_ids": host[offsets[2] : offsets[3]],
+        "host_num_tokens_per_slot": host[offsets[3] : offsets[4]],
+        "host_slot_start_offsets": host[offsets[4] : offsets[5]],
+    }
+
+
+def test_copy_lora_domain_uses_one_host_staged_metadata_copy():
+    import nanovllm_voxcpm.engine.model_runner as model_runner
+    from nanovllm_voxcpm.utils.context import LM_LORA_DOMAIN, LoRAContext
+
+    runner = object.__new__(model_runner.BaseModelRunner)
+    domain_vars = _make_host_staged_domain_vars(max_rows=6, max_lora_buckets=3)
+    domain_vars["host_active_slot_ids"].copy_(torch.tensor([-1, 0, 1], dtype=torch.int32))
+    graph_vars = {"lora_domains": {LM_LORA_DOMAIN: domain_vars}}
+    context = LoRAContext(
+        token_to_slot=torch.tensor([1, -1, 0], dtype=torch.int32),
+        no_lora_flag=False,
+        num_active_loras=2,
+        host_token_to_slot=[1, -1, 0],
+        host_token_indices_sorted_by_slot=[2, 0],
+        host_active_slot_ids=[0, 1],
+        host_num_tokens_per_slot=[1, 1],
+    )
+
+    runner._copy_lora_domain_to_graph_vars(graph_vars, LM_LORA_DOMAIN, context)
+
+    assert domain_vars["copy_event"].recorded == 1
+    assert domain_vars["token_to_slot"].tolist() == [1, -1, 0, -1, -1, -1]
+    assert domain_vars["token_indices_sorted_by_slot"][:2].tolist() == [2, 0]
+    assert domain_vars["num_tokens_per_slot"].tolist() == [0, 1, 1]
+    assert domain_vars["slot_start_offsets"].tolist() == [0, 0, 1, 2]
+
+
+def test_copy_lora_domain_waits_before_reusing_host_staging():
+    import nanovllm_voxcpm.engine.model_runner as model_runner
+    from nanovllm_voxcpm.utils.context import LM_LORA_DOMAIN, LoRAContext
+
+    runner = object.__new__(model_runner.BaseModelRunner)
+    domain_vars = _make_host_staged_domain_vars(max_rows=2, max_lora_buckets=1)
+    domain_vars["copy_pending"] = True
+    graph_vars = {"lora_domains": {LM_LORA_DOMAIN: domain_vars}}
+
+    runner._copy_lora_domain_to_graph_vars(
+        graph_vars,
+        LM_LORA_DOMAIN,
+        LoRAContext(no_lora_flag=True, num_active_loras=0),
+    )
+
+    assert domain_vars["copy_event"].synchronized == 1
+    assert domain_vars["copy_event"].recorded == 1
 
 
 def test_copy_lora_domain_no_lora_flag_resets_to_sentinel():
@@ -1479,3 +1607,153 @@ def test_allocate_kv_cache_pre_set_num_blocks_skips_auto(monkeypatch):
 
     assert cuda_called == []
     assert runner._config.num_kvcache_blocks == 100
+
+
+def test_prefill_diffusion_graph_pads_to_bucket_and_returns_real_batch(monkeypatch):
+    import nanovllm_voxcpm.engine.model_runner as model_runner
+    from nanovllm_voxcpm.utils.context import DIT_LORA_DOMAIN, LoRAContext
+
+    runner = object.__new__(model_runner.BaseModelRunner)
+    runner.graph_bs = [1, 2, 4]
+
+    diffusion_inputs = {
+        "mu": torch.arange(9, dtype=torch.float32).reshape(3, 3),
+        "cond": torch.ones(3, 3, 2),
+        "temperature": torch.ones(3),
+        "cfg_value": torch.ones(3),
+        "z_noise": torch.ones(3, 3, 2),
+    }
+
+    class FakeModel:
+        def forward_backbone(self, **inputs):
+            return diffusion_inputs, {"stop_flag": torch.tensor([0, 1, 0])}
+
+        def forward_diffusion(self, **inputs):
+            raise AssertionError("captured graph should be replayed")
+
+    runner.model = FakeModel()
+    graph_inputs = {
+        name: torch.full((4, *value.shape[1:]), -1, dtype=value.dtype) for name, value in diffusion_inputs.items()
+    }
+    graph_outputs = torch.zeros(4, 2, 3)
+    runner.prefill_diffusion_graph_vars = {
+        "inputs": graph_inputs,
+        "outputs": graph_outputs,
+        "lora_domains": {},
+    }
+
+    class FakeGraph:
+        def __init__(self):
+            self.replayed = False
+
+        def replay(self):
+            self.replayed = True
+            graph_outputs[:4] = graph_inputs["mu"][:4, None, :].expand(-1, 2, -1)
+
+    graph = FakeGraph()
+    runner.prefill_diffusion_graphs = {"base": {4: graph}, "lora": {}}
+    monkeypatch.setattr(runner, "_set_graph_lora_context", lambda *args, **kwargs: None)
+
+    outputs = runner._run_prefill_with_diffusion_graph(
+        inputs={},
+        lora_contexts={DIT_LORA_DOMAIN: LoRAContext(no_lora_flag=True, num_active_loras=0)},
+    )
+
+    assert graph.replayed is True
+    assert outputs["latents"].shape == (3, 2, 3)
+    assert torch.equal(outputs["latents"][:, 0], diffusion_inputs["mu"])
+    assert torch.count_nonzero(graph_inputs["mu"][3]) == 0
+    assert outputs["stop_flag"].tolist() == [0, 1, 0]
+
+
+def test_expand_dit_lora_slots_inserts_padding_inside_each_cfg_branch():
+    from nanovllm_voxcpm.engine.model_runner import expand_dit_lora_slots
+
+    slots = expand_dit_lora_slots(
+        sample_to_slot=[3, 7],
+        sequence_length=2,
+        cfg_branches=2,
+        padded_batch_size=4,
+    )
+
+    assert slots == [
+        3,
+        3,
+        7,
+        7,
+        -1,
+        -1,
+        -1,
+        -1,
+        3,
+        3,
+        7,
+        7,
+        -1,
+        -1,
+        -1,
+        -1,
+    ]
+
+
+def test_expand_dit_lora_slots_rejects_smaller_padding_bucket():
+    from nanovllm_voxcpm.engine.model_runner import expand_dit_lora_slots
+
+    with pytest.raises(ValueError, match="cannot be smaller"):
+        expand_dit_lora_slots([0, 1], sequence_length=2, cfg_branches=2, padded_batch_size=1)
+
+
+def test_prefill_diffusion_eager_fallback_removes_graph_bucket_lora_padding():
+    from types import SimpleNamespace
+
+    from nanovllm_voxcpm.engine.model_runner import BaseModelRunner, expand_dit_lora_slots
+    from nanovllm_voxcpm.utils.context import (
+        DIT_LORA_DOMAIN,
+        build_lora_context_from_token_to_slot,
+        get_lora_context,
+        reset_all_contexts,
+    )
+
+    runner = object.__new__(BaseModelRunner)
+    runner.graph_bs = [1, 2, 4]
+    runner.cfg_branches = 2
+    runner.patch_size = 1
+    runner.dit_lora_seq_len_offset = 0
+    runner.lora_config = SimpleNamespace(enable_dit=True)
+    runner.prefill_diffusion_graphs = {"base": {}, "lora": {}}
+
+    diffusion_inputs = {
+        "mu": torch.zeros(3, 2),
+        "cond": torch.zeros(3, 2, 1),
+        "temperature": torch.ones(3),
+        "cfg_value": torch.ones(3),
+        "z_noise": torch.ones(3, 2, 1),
+    }
+    captured = {}
+
+    class FakeModel:
+        def forward_backbone(self, **inputs):
+            return diffusion_inputs, {"stop_flag": torch.zeros(3, dtype=torch.int64)}
+
+        def forward_diffusion(self, **inputs):
+            captured["token_to_slot"] = get_lora_context(DIT_LORA_DOMAIN).token_to_slot.clone()
+            return torch.zeros(3, 1, 2)
+
+    runner.model = FakeModel()
+    padded_slots = expand_dit_lora_slots(
+        [0, 1, 2],
+        sequence_length=2,
+        cfg_branches=2,
+        padded_batch_size=4,
+    )
+    padded_context = build_lora_context_from_token_to_slot(torch.tensor(padded_slots, dtype=torch.int32))
+
+    try:
+        runner._run_prefill_with_diffusion_graph(
+            inputs={},
+            lora_contexts={DIT_LORA_DOMAIN: padded_context},
+        )
+    finally:
+        reset_all_contexts()
+
+    assert captured["token_to_slot"].tolist() == [0, 0, 1, 1, 2, 2, 0, 0, 1, 1, 2, 2]

--- a/tests/unit/test_model_runner_extended.py
+++ b/tests/unit/test_model_runner_extended.py
@@ -813,6 +813,8 @@ def test_make_graph_domain_buffers_shapes():
 
     assert (buffers["token_to_slot"] == -1).all()
     assert buffers["active_slot_ids"].tolist() == [-1, 0, 1]
+    assert "host_staging" not in buffers
+    assert "copy_event" not in buffers
 
 
 def test_write_shm_inline_small_payload():

--- a/tests/unit/test_streaming_vae.py
+++ b/tests/unit/test_streaming_vae.py
@@ -1,0 +1,167 @@
+import copy
+
+import pytest
+import torch
+from torch import nn
+
+from nanovllm_voxcpm.layers.streaming_vae import BatchedStreamingVAEDecoder
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "nanovllm_voxcpm.layers.audio_vae",
+        "nanovllm_voxcpm.layers.audio_vae_v2",
+    ],
+)
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param("cuda", marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")),
+    ],
+)
+def test_streaming_vae_matches_full_decode_with_dynamic_batch_order(module_name, device):
+    module = __import__(module_name, fromlist=["CausalConv1d", "CausalTransposeConv1d"])
+    causal_conv = module.CausalConv1d
+    causal_transpose_conv = module.CausalTransposeConv1d
+
+    class TinyVAE(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Sequential(
+                causal_conv(2, 4, kernel_size=3, padding=1),
+                nn.SiLU(),
+                causal_transpose_conv(4, 1, kernel_size=4, stride=2, padding=1),
+            )
+
+        def decode(self, z):
+            return self.decoder(z)
+
+    torch.manual_seed(0)
+    streaming_vae = TinyVAE().to(device)
+    reference_vae = copy.deepcopy(streaming_vae)
+    decoder = BatchedStreamingVAEDecoder(streaming_vae, causal_conv, causal_transpose_conv)
+
+    a_chunks = [torch.randn(1, 2, 2, device=device) for _ in range(3)]
+    b_chunks = [torch.randn(1, 2, 2, device=device) for _ in range(3)]
+    expected_a = reference_vae.decode(torch.cat(a_chunks, dim=-1))
+    expected_b = reference_vae.decode(torch.cat(b_chunks, dim=-1))
+
+    first = decoder.decode_chunks(torch.cat([a_chunks[0], b_chunks[0]], dim=0), ["a", "b"])
+    second = decoder.decode_chunks(torch.cat([b_chunks[1], a_chunks[1]], dim=0), ["b", "a"])
+    third = decoder.decode_chunks(torch.cat([a_chunks[2], b_chunks[2]], dim=0), ["a", "b"])
+    actual_a = torch.cat([first[0:1], second[1:2], third[0:1]], dim=-1)
+    actual_b = torch.cat([first[1:2], second[0:1], third[1:2]], dim=-1)
+
+    torch.testing.assert_close(actual_a, expected_a, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(actual_b, expected_b, rtol=1e-5, atol=1e-6)
+
+
+def test_streaming_vae_primes_context_once_and_releases_state():
+    from nanovllm_voxcpm.layers.audio_vae import CausalConv1d, CausalTransposeConv1d
+
+    class TinyVAE(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Sequential(
+                CausalConv1d(1, 2, kernel_size=3, padding=1),
+                CausalTransposeConv1d(2, 1, kernel_size=4, stride=2, padding=1),
+            )
+
+        def decode(self, z):
+            return self.decoder(z)
+
+    torch.manual_seed(1)
+    streaming_vae = TinyVAE()
+    reference_vae = copy.deepcopy(streaming_vae)
+    decoder = BatchedStreamingVAEDecoder(streaming_vae, CausalConv1d, CausalTransposeConv1d)
+    context = torch.randn(1, 1, 3)
+    chunk = torch.randn(1, 1, 2)
+
+    expected = reference_vae.decode(torch.cat([context, chunk], dim=-1))[..., -4:]
+    first = decoder.decode_chunks(chunk, ["request"], [context])
+    decoder.release("request")
+    second = decoder.decode_chunks(chunk, ["request"], [context])
+
+    torch.testing.assert_close(first, expected, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(second, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_streaming_vae_rejects_duplicate_stream_ids():
+    from nanovllm_voxcpm.layers.audio_vae import CausalConv1d, CausalTransposeConv1d
+
+    class TinyVAE(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Sequential(CausalConv1d(1, 1, kernel_size=3, padding=1))
+
+        def decode(self, z):
+            return self.decoder(z)
+
+    decoder = BatchedStreamingVAEDecoder(TinyVAE(), CausalConv1d, CausalTransposeConv1d)
+    with pytest.raises(ValueError, match="unique"):
+        decoder.decode_chunks(torch.zeros(2, 1, 1), ["same", "same"])
+
+
+def test_streaming_vae_preserves_regular_decode_path():
+    from nanovllm_voxcpm.layers.audio_vae import CausalConv1d, CausalTransposeConv1d
+
+    class TinyVAE(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Sequential(
+                CausalConv1d(1, 2, kernel_size=3, padding=1),
+                CausalTransposeConv1d(2, 1, kernel_size=4, stride=2, padding=1),
+            )
+
+        def decode(self, z):
+            return self.decoder(z)
+
+    torch.manual_seed(2)
+    vae = TinyVAE()
+    reference_vae = copy.deepcopy(vae)
+    BatchedStreamingVAEDecoder(vae, CausalConv1d, CausalTransposeConv1d)
+    inputs = torch.randn(1, 1, 4)
+
+    torch.testing.assert_close(vae.decode(inputs), reference_vae.decode(inputs))
+
+
+def test_streaming_vae_failed_decode_does_not_advance_state():
+    from nanovllm_voxcpm.layers.audio_vae import CausalConv1d, CausalTransposeConv1d
+
+    class FailOnce(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.should_fail = True
+
+        def forward(self, x):
+            if self.should_fail:
+                self.should_fail = False
+                raise RuntimeError("decode failed")
+            return x
+
+    class TinyVAE(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fail_once = FailOnce()
+            self.decoder = nn.Sequential(
+                CausalConv1d(1, 1, kernel_size=3, padding=1),
+                self.fail_once,
+            )
+
+        def decode(self, z):
+            return self.decoder(z)
+
+    torch.manual_seed(3)
+    vae = TinyVAE()
+    reference_vae = copy.deepcopy(vae)
+    reference_vae.fail_once.should_fail = False
+    decoder = BatchedStreamingVAEDecoder(vae, CausalConv1d, CausalTransposeConv1d)
+    chunk = torch.randn(1, 1, 2)
+
+    with pytest.raises(RuntimeError, match="decode failed"):
+        decoder.decode_chunks(chunk, ["request"])
+    actual = decoder.decode_chunks(chunk, ["request"])
+
+    torch.testing.assert_close(actual, reference_vae.decode(chunk))

--- a/tests/unit/test_streaming_vae.py
+++ b/tests/unit/test_streaming_vae.py
@@ -226,3 +226,159 @@ def test_streaming_vae_failed_decode_does_not_advance_state():
     actual = decoder.decode_chunks(chunk, ["request"])
 
     torch.testing.assert_close(actual, reference_vae.decode(chunk))
+
+
+def _build_multistage_vae(causal_conv, causal_transpose_conv):
+    """A deep causal decoder that chains dilated convs with multiple strided upsamplers.
+
+    This exercises whether per-layer streaming state retains the *full* receptive
+    field across a multi-stage stack (initial conv, dilated residual convs, and
+    two transpose-conv upsamplers), not just the single-stage TinyVAE above.
+    """
+
+    class MultiStageVAE(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Sequential(
+                causal_conv(2, 8, kernel_size=7, padding=3),
+                nn.SiLU(),
+                causal_transpose_conv(8, 8, kernel_size=4, stride=2, padding=1),
+                causal_conv(8, 8, kernel_size=3, padding=2, dilation=2),
+                nn.SiLU(),
+                causal_transpose_conv(8, 4, kernel_size=8, stride=4, padding=2),
+                causal_conv(4, 1, kernel_size=7, padding=3),
+            )
+
+        def decode(self, z):
+            return self.decoder(z)
+
+    return MultiStageVAE()
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "nanovllm_voxcpm.layers.audio_vae",
+        "nanovllm_voxcpm.layers.audio_vae_v2",
+    ],
+)
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param("cuda", marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")),
+    ],
+)
+def test_streaming_vae_matches_full_decode_across_deep_multistage_stack(module_name, device):
+    module = __import__(module_name, fromlist=["CausalConv1d", "CausalTransposeConv1d"])
+    causal_conv = module.CausalConv1d
+    causal_transpose_conv = module.CausalTransposeConv1d
+
+    torch.manual_seed(5)
+    streaming_vae = _build_multistage_vae(causal_conv, causal_transpose_conv).to(device)
+    reference_vae = copy.deepcopy(streaming_vae)
+    decoder = BatchedStreamingVAEDecoder(streaming_vae, causal_conv, causal_transpose_conv)
+
+    chunks = [torch.randn(1, 2, 4, device=device) for _ in range(5)]
+    expected = reference_vae.decode(torch.cat(chunks, dim=-1))
+
+    streamed = torch.cat([decoder.decode_chunks(chunk, ["stream"]) for chunk in chunks], dim=-1)
+
+    torch.testing.assert_close(streamed, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param("cuda", marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")),
+    ],
+)
+def test_streaming_vae_primes_multistage_context_matches_full_decode(device):
+    from nanovllm_voxcpm.layers.audio_vae import CausalConv1d, CausalTransposeConv1d
+
+    torch.manual_seed(6)
+    streaming_vae = _build_multistage_vae(CausalConv1d, CausalTransposeConv1d).to(device)
+    reference_vae = copy.deepcopy(streaming_vae)
+    decoder = BatchedStreamingVAEDecoder(streaming_vae, CausalConv1d, CausalTransposeConv1d)
+
+    prime = torch.randn(1, 2, 4, device=device)
+    gen_chunks = [torch.randn(1, 2, 4, device=device) for _ in range(3)]
+    expected = reference_vae.decode(torch.cat([prime, *gen_chunks], dim=-1))
+
+    streamed = torch.cat(
+        [
+            decoder.decode_chunks(chunk, ["stream"], [prime] if index == 0 else [None])
+            for index, chunk in enumerate(gen_chunks)
+        ],
+        dim=-1,
+    )
+
+    post_prime_reference = expected[..., -streamed.size(-1) :]
+    torch.testing.assert_close(streamed, post_prime_reference, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("kernel_size", "stride"),
+    [
+        (6, 2),
+        (8, 4),
+        pytest.param(
+            5,
+            2,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="context = kernel // stride - 1 under-retains when stride does not divide kernel",
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param("cuda", marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")),
+    ],
+)
+def test_streaming_vae_transpose_conv_matches_full_decode_for_non_double_stride(kernel_size, stride, device):
+    """Lock the streaming-context formula for transpose convs where kernel != 2 * stride.
+
+    Shipped decoders hard-code ``kernel_size = 2 * stride``, so ``context = kernel //
+    stride - 1`` always equals the true required context and streaming stays exact.
+    Divisible ratios such as (6, 2) and (8, 4) must therefore match a full decode; the
+    xfail (5, 2) case documents that a non-divisible ratio under-retains context under
+    the current formula, guarding against silently relying on that unsupported config.
+    """
+    from nanovllm_voxcpm.layers.audio_vae import CausalConv1d, CausalTransposeConv1d
+
+    padding = (kernel_size - stride + 1) // 2
+    output_padding = (2 * padding + stride - kernel_size) % stride
+
+    class TinyTransposeVAE(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Sequential(
+                CausalTransposeConv1d(
+                    2,
+                    1,
+                    kernel_size=kernel_size,
+                    stride=stride,
+                    padding=padding,
+                    output_padding=output_padding,
+                ),
+            )
+
+        def decode(self, z):
+            return self.decoder(z)
+
+    torch.manual_seed(7)
+    streaming_vae = TinyTransposeVAE().to(device)
+    reference_vae = copy.deepcopy(streaming_vae)
+    decoder = BatchedStreamingVAEDecoder(streaming_vae, CausalConv1d, CausalTransposeConv1d)
+
+    chunks = [torch.randn(1, 2, 3, device=device) for _ in range(4)]
+    expected = reference_vae.decode(torch.cat(chunks, dim=-1))
+
+    streamed = torch.cat([decoder.decode_chunks(chunk, ["stream"]) for chunk in chunks], dim=-1)
+
+    torch.testing.assert_close(streamed, expected, rtol=1e-5, atol=1e-6)

--- a/tests/unit/test_streaming_vae.py
+++ b/tests/unit/test_streaming_vae.py
@@ -58,6 +58,67 @@ def test_streaming_vae_matches_full_decode_with_dynamic_batch_order(module_name,
     torch.testing.assert_close(actual_b, expected_b, rtol=1e-5, atol=1e-6)
 
 
+def test_streaming_vae_pads_to_fixed_batch_bucket_and_cleans_dummy_state():
+    from nanovllm_voxcpm.layers.audio_vae import CausalConv1d, CausalTransposeConv1d
+
+    class TinyVAE(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Sequential(CausalConv1d(1, 1, kernel_size=3, padding=1))
+            self.seen_batch_sizes = []
+
+        def decode(self, z):
+            self.seen_batch_sizes.append(z.size(0))
+            return self.decoder(z)
+
+    torch.manual_seed(4)
+    vae = TinyVAE()
+    reference_vae = copy.deepcopy(vae)
+    decoder = BatchedStreamingVAEDecoder(
+        vae,
+        CausalConv1d,
+        CausalTransposeConv1d,
+        max_batch_size=4,
+    )
+    chunks = torch.randn(3, 1, 2)
+    stream_ids = ["a", "b", "c"]
+
+    actual = decoder.decode_chunks(chunks, stream_ids)
+
+    torch.testing.assert_close(actual, reference_vae.decode(chunks))
+    assert vae.seen_batch_sizes == [4]
+    for layer_states in decoder._states.values():
+        assert set(layer_states) == set(stream_ids)
+
+
+def test_streaming_vae_warmup_initializes_all_buckets_without_retaining_state():
+    from nanovllm_voxcpm.layers.audio_vae import CausalConv1d, CausalTransposeConv1d
+
+    class TinyVAE(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Sequential(CausalConv1d(1, 1, kernel_size=3, padding=1))
+            self.seen_batch_sizes = []
+
+        def decode(self, z):
+            self.seen_batch_sizes.append(z.size(0))
+            return self.decoder(z)
+
+    vae = TinyVAE()
+    decoder = BatchedStreamingVAEDecoder(
+        vae,
+        CausalConv1d,
+        CausalTransposeConv1d,
+        max_batch_size=4,
+    )
+
+    decoder.warmup(latent_channels=1, chunk_size=2)
+
+    assert vae.seen_batch_sizes == [1, 2, 4]
+    assert not decoder._initialized_streams
+    assert all(not layer_states for layer_states in decoder._states.values())
+
+
 def test_streaming_vae_primes_context_once_and_releases_state():
     from nanovllm_voxcpm.layers.audio_vae import CausalConv1d, CausalTransposeConv1d
 

--- a/tests/unit/test_voxcpm2_chunk_sizes.py
+++ b/tests/unit/test_voxcpm2_chunk_sizes.py
@@ -43,6 +43,25 @@ def test_audio_vae_v2_uses_fixed_batch_shaped_sr_idx():
     assert sr_idx.tolist() == [3, 3, 3]
 
 
+def test_voxcpm2_runner_prepares_fp16_decoder_and_folds_weight_norm():
+    from torch import nn
+    from torch.nn.utils import weight_norm
+
+    from nanovllm_voxcpm.models.voxcpm2.runner import VoxCPM2Runner
+
+    runner = VoxCPM2Runner.__new__(VoxCPM2Runner)
+    runner.vae = type("_VAE", (), {})()
+    runner.vae.decoder = nn.Sequential(weight_norm(nn.Conv1d(2, 2, kernel_size=1)))
+
+    runner._prepare_vae_decoder_for_inference()
+
+    conv = runner.vae.decoder[0]
+    assert conv.weight.dtype == torch.float16
+    assert not hasattr(conv, "weight_g")
+    assert not hasattr(conv, "weight_v")
+    assert conv._forward_pre_hooks == {}
+
+
 def test_voxcpm2_engine_aligns_prompt_audio_with_encoder_chunk_size():
     from nanovllm_voxcpm.models.voxcpm2.engine import VoxCPM2Engine
 


### PR DESCRIPTION
## Summary
- capture prefill diffusion independently from the variable-shape backbone, including graph bucketing, CFG-aware LoRA padding, and eager fallback
- reduce per-request LoRA launch overhead with packed graph metadata transfers and skip redundant slot clears during adapter admission
- retain per-sequence causal VAE convolution state so each decode step processes only the new latent chunk
- run the VoxCPM2 VAE decoder in FP16 and fold inference-only weight normalization after checkpoint loading
- add deterministic graph/eager/concurrent waveform calibration tooling

## Profiling and bottleneck attribution
Nsight Systems measurements on one H800 show why the original PR's large TTFB gain only weakly affected wall time and RTF: TTFB is paid once, while 180 decode chunks dominate a 100-word request, and RTF excludes TTFB by definition.

| Eager per-chunk stage | Mean time |
|---|---:|
| DiT diffusion (9 estimator calls) | 136.9 ms |
| Base LM | 29.2 ms |
| Feature encoder | 14.2 ms |
| Streaming VAE decode | 14.9 ms |
| Residual LM | 4.8 ms |

CUDA graphs reduce the model body to an approximately 8 ms replay in the instrumented trace, leaving the uncaptured streaming VAE at approximately 15 ms and 434 GPU operations per chunk. Weight-normalization kernels alone represented about 1.9% of eager GPU kernel time. This made decoder precision and static weight folding the next evidence-backed target.

Rejected experiments:
- whole-decoder `torch.compile`: state aliasing conflicted with compiler CUDA graphs; disabling compiler graphs pushed first-use autotuning beyond four minutes
- explicit stateful VAE CUDA graph: numerically correct after output stabilization, but regressed c1 wall time by 6.6%, so it was removed

## Benchmark results
Fixed seed 123, 100-word English input, `max_generate_length=2000`, one H800.

Original PR versus `main`:

| Metric | `main` | Original PR | Change |
|---|---:|---:|---:|
| TTFB p50 | 171.5 ms | 61.1 ms | **-64.4%** |
| Wall time | 2.990 s | 2.838 s | **-5.1%** |
| Chunks/s | 60.20 | 63.43 | **+5.4%** |
| RTF | 0.0979 | 0.0964 | **-1.5%** |

Follow-up optimization versus the original PR (5 warmups, 20 measured iterations at c1):

| Metric | Original PR | Updated PR | Change |
|---|---:|---:|---:|
| Wall time | 2.8398 ± 0.0222 s | 2.7575 ± 0.0203 s | **-2.9%** |
| Chunks/s | 63.389 ± 0.496 | 65.280 ± 0.481 | **+3.0%** |
| RTF | 0.0965 ± 0.0008 | 0.0937 ± 0.0007 | **-2.9%** |
| TTFB p50 | 61.0 ± 2.7 ms | 59.0 ± 2.5 ms | **-3.3%** |

At concurrency 4 (3 warmups, 10 measured iterations), wall time improved from 3.2408 to 3.0972 s (**-4.4%**), chunks/s from 224.65 to 235.06 (**+4.6%**), and RTF from 0.1090 to 0.1041 (**-4.5%**).

No compatible real LoRA checkpoint was available on the host. Existing LoRA request-boundary results remain: metadata update latency improved 61-65% for 1-256 rows, while the one-time 4096-row prefill case regressed by about 0.26 ms.

## Correctness calibration
Deterministic waveform comparisons use the same model path, prompt, seed, and execution mode before/after the decoder change.

| Calibration | RMSE | p99.9 abs error | Max abs error | Correlation |
|---|---:|---:|---:|---:|
| CUDA graph, c1, 1,382,400 samples | 1.23e-4 | 6.74e-4 | 1.64e-3 | 0.99999915 |
| Eager, c1, 1,336,320 samples | 1.11e-4 | 5.89e-4 | 1.38e-3 | 0.99999914 |
| Concurrent c4, worst request | 3.76e-4 | 2.22e-3 | 1.01e-2 | 0.99999631 |

Graph and eager already produce different trajectories and stop lengths, so calibration compares baseline versus optimized within each mode rather than treating graph/eager as bitwise references. All before/after pairs retained identical lengths within their mode.

## Test plan
- [x] `python -m pytest tests/unit -q` on H800 — **550 passed, 1 skipped**
- [x] CPU and CUDA streaming VAE parity, dynamic batch reordering, context priming, state cleanup, and transactional failure tests
- [x] Deterministic graph, eager, and c4 concurrent waveform calibration
- [x] Concurrency 17 graph-bucket stress: 3 measured iterations, 5.5867 ± 0.0529 s wall, no failures
- [x] `python -m compileall -q nanovllm_voxcpm benchmark/calibrate_waveform.py`
- [ ] Deployment tests require the deployment environment; collection in the core H800 env stops because `fastapi` is not installed

Made with [Cursor](https://cursor.com)