### PR TITLE
fix(lora): align DiT slots with CFG batch order

### DIFF
--- a/nanovllm_voxcpm/engine/model_runner.py
+++ b/nanovllm_voxcpm/engine/model_runner.py
@@ -171,6 +171,15 @@ def assign_outputs(inputs, outputs, bs):
         outputs[k][:bs] = inputs[k]
 
 
+def expand_dit_lora_slots(
+    sample_to_slot: list[int],
+    sequence_length: int,
+    cfg_branches: int,
+) -> list[int]:
+    """Expand sample slots in the branch-major order used by CFG."""
+    return [slot for _ in range(cfg_branches) for slot in sample_to_slot for _ in range(sequence_length)]
+
+
 def _clear_lora_slot_modules(modules, slot_id: int, module_names: list[str] | None = None) -> None:
     """Zero out LoRA weights for ``slot_id`` across ``modules``.
 
@@ -285,15 +294,17 @@ class BaseModelRunner:
     def run(self, seqs: list[RunnerTask], is_prefill: bool):
         raise NotImplementedError()
 
-    def _dit_lora_rows_per_sample(self) -> int:
+    def _dit_lora_sequence_length(self) -> int:
         lora_config = getattr(self, "lora_config", None)
         if not (lora_config and getattr(lora_config, "enable_dit", False)):
             return 0
-        return self.cfg_branches * (self.dit_lora_seq_len_offset + 2 * self.patch_size)
+        return self.dit_lora_seq_len_offset + 2 * self.patch_size
+
+    def _dit_lora_rows_per_sample(self) -> int:
+        return self.cfg_branches * self._dit_lora_sequence_length()
 
     def _build_lora_contexts(self, seqs: list[RunnerTask], token_counts: list[int]) -> dict[str, LoRAContext]:
         adapter_ids = [seq.adapter_id for seq in seqs]
-        dit_rows_per_sample = self._dit_lora_rows_per_sample()
         if not any(adapter_id is not None for adapter_id in adapter_ids):
             # No active LoRA anywhere in this batch. Build just the LM
             # ``token_to_slot=[-1,...]`` tensor; the PROJ and DIT domains can
@@ -316,7 +327,11 @@ class BaseModelRunner:
             LM_LORA_DOMAIN: build_lora_context_from_batch_plan(plan),
             PROJ_LORA_DOMAIN: build_lora_context_from_slot_list(sample_to_slot),
             DIT_LORA_DOMAIN: build_lora_context_from_slot_list(
-                [slot for slot in sample_to_slot for _ in range(dit_rows_per_sample)]
+                expand_dit_lora_slots(
+                    sample_to_slot,
+                    sequence_length=self._dit_lora_sequence_length(),
+                    cfg_branches=self.cfg_branches,
+                )
             ),
         }
 

--- a/tests/unit/test_model_runner_extended.py
+++ b/tests/unit/test_model_runner_extended.py
@@ -224,6 +224,37 @@ def test_expand_dit_lora_slots_uses_cfg_branch_major_order():
     ]
 
 
+def test_expand_dit_lora_slots_no_cross_voice_bleed_when_co_batched():
+    """Regression for PR #80: two distinct voices in one DiT batch must not
+    share adapters. Pre-fix sample-major expansion made sample B's cond rows
+    run under sample A's adapter, blending both voices.
+    """
+    from nanovllm_voxcpm.engine.model_runner import expand_dit_lora_slots
+
+    slot_a, slot_b = 3, 7
+    sample_to_slot = [slot_a, slot_b]
+    seq_len = 3
+    cfg_branches = 2
+
+    rows = expand_dit_lora_slots(sample_to_slot, sequence_length=seq_len, cfg_branches=cfg_branches)
+
+    assert len(rows) == cfg_branches * len(sample_to_slot) * seq_len
+
+    block = 0
+    for branch in range(cfg_branches):
+        for sample_idx, expected_slot in enumerate(sample_to_slot):
+            seq_rows = rows[block * seq_len : (block + 1) * seq_len]
+            assert seq_rows == [expected_slot] * seq_len, (
+                f"branch {branch} sample {sample_idx} rows {seq_rows} "
+                f"leaked another voice's adapter (expected all {expected_slot})"
+            )
+            block += 1
+
+    b_rows = [slot for slot in rows if slot == slot_b]
+    assert slot_a not in b_rows
+    assert b_rows == [slot_b] * (cfg_branches * seq_len)
+
+
 @pytest.mark.gpu
 def test_build_lora_contexts_no_adapters_returns_empty_lm_and_no_lora_flags():
     import nanovllm_voxcpm.engine.model_runner as model_runner

--- a/tests/unit/test_model_runner_extended.py
+++ b/tests/unit/test_model_runner_extended.py
@@ -209,6 +209,21 @@ def test_dit_lora_rows_per_sample_with_dit_enabled():
     assert runner._dit_lora_rows_per_sample() == 40
 
 
+def test_expand_dit_lora_slots_uses_cfg_branch_major_order():
+    from nanovllm_voxcpm.engine.model_runner import expand_dit_lora_slots
+
+    assert expand_dit_lora_slots([3, 7], sequence_length=2, cfg_branches=2) == [
+        3,
+        3,
+        7,
+        7,
+        3,
+        3,
+        7,
+        7,
+    ]
+
+
 @pytest.mark.gpu
 def test_build_lora_contexts_no_adapters_returns_empty_lm_and_no_lora_flags():
     import nanovllm_voxcpm.engine.model_runner as model_runner
@@ -879,7 +894,14 @@ def test_build_lora_contexts_with_active_adapter():
     from nanovllm_voxcpm.utils.context import LM_LORA_DOMAIN, PROJ_LORA_DOMAIN, DIT_LORA_DOMAIN
 
     runner = object.__new__(model_runner.BaseModelRunner)
-    runner.lora_config = None
+
+    class _FakeLoraCfg:
+        enable_dit = True
+
+    runner.lora_config = _FakeLoraCfg()
+    runner.cfg_branches = 2
+    runner.dit_lora_seq_len_offset = 0
+    runner.patch_size = 1
     runtime = LoRARuntime(max_loras=2, max_lora_rank=4)
     payload = LoRAModelPayload(modules={}, rank=1, alpha=1.0)
     runtime.register_lora("adapter_a", payload, adapter_id=3)
@@ -914,6 +936,7 @@ def test_build_lora_contexts_with_active_adapter():
     assert DIT_LORA_DOMAIN in contexts
     assert len(load_calls) == 1
     assert load_calls[0] == ([3, None], [2, 1])
+    assert contexts[DIT_LORA_DOMAIN].token_to_slot.tolist() == [0, 0, -1, -1, 0, 0, -1, -1]
 
 
 def test_load_lora_slot_unknown_module_raises():


### PR DESCRIPTION
## Summary
- expand DiT LoRA slots in classifier-free-guidance branch-major order
- prevent concurrent voices from applying another sample's adapter during DiT decoding
- add regression coverage for multi-adapter row mapping

## Test plan
- [x] `python -m pytest tests/unit/test_model_runner_extended.py -q` (54 passed, 8 skipped)

Made with [Cursor](https://cursor.com)