### PR TITLE
fix: detect worker death and fail-fast pending requests

### DIFF
--- a/examples/verify_worker_health.py
+++ b/examples/verify_worker_health.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Manual verification: Worker death detection in AsyncVoxCPMServer.
+
+This script demonstrates that when the worker process dies unexpectedly,
+pending requests fail fast with a clear error instead of hanging forever.
+
+It imports the ACTUAL AsyncVoxCPMServer and replaces main_loop with a fake
+worker that sleeps (no GPU required).
+
+Usage:
+    python examples/verify_worker_health.py
+
+Expected output (WITH fix):
+    [0.0s] Starting fake worker process...
+    [0.0s] Worker PID: <pid>
+    [0.3s] Worker ready (init_ok received)
+    [0.3s] Submitting request...
+    [0.8s] Killing worker (simulating OOM crash)...
+    [~0.9s] ✅ Request failed with: RuntimeError('VoxCPM worker process died unexpectedly')
+    [~0.9s] Attempting new submission after death...
+    [~0.9s] ✅ New submission rejected: RuntimeError('...')
+
+    PASS: Worker death detected in ~0.1s (would hang forever without fix)
+
+Expected output (WITHOUT fix — before this PR):
+    ... (hangs at "Killing worker" step, times out after 5s)
+    FAIL: Worker death was not detected (hung forever)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+import threading
+import time
+
+# Ensure the project root is importable when running standalone
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tests"))
+
+# Disable torch.compile (must happen BEFORE any nanovllm import)
+os.environ["TORCHDYNAMO_DISABLE"] = "1"
+
+from _shims import install_gpu_shims  # noqa: E402
+
+install_gpu_shims()
+
+import torch  # noqa: E402
+
+# Replace @torch.compile with a no-op so activation.py doesn't trigger
+# the _inductor import chain (which fails with incompatible triton).
+torch.compile = lambda fn=None, *args, **kwargs: fn if fn is not None else (lambda f: f)  # type: ignore[assignment]
+
+import torch.multiprocessing as mp  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fake worker (no GPU needed)
+# ---------------------------------------------------------------------------
+
+
+def _fake_worker_sleep(queue_in, queue_out, args, kwargs):
+    """Worker that acks init then sleeps forever (will be SIGKILL'd)."""
+    queue_out.put({"type": "init_ok"})
+    while True:
+        time.sleep(60)
+
+
+# ---------------------------------------------------------------------------
+# Main verification
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    # Import the real server module and monkeypatch main_loop
+    import nanovllm_voxcpm.models.voxcpm.server as mod
+
+    mod.main_loop = _fake_worker_sleep
+
+    t0 = time.monotonic()
+
+    def elapsed() -> str:
+        return f"[{time.monotonic() - t0:.1f}s]"
+
+    print(f"{elapsed()} Starting fake worker process...")
+
+    # Build the server using the real class (bypassing __init__ to avoid
+    # requiring model_path argument, but using all real queue infrastructure)
+    server = mod.AsyncVoxCPMServer.__new__(mod.AsyncVoxCPMServer)
+    ctx = mp.get_context("spawn")
+    server.queue_in = ctx.Queue()
+    server.queue_out = ctx.Queue()
+    server.process = ctx.Process(
+        target=_fake_worker_sleep,
+        args=(server.queue_in, server.queue_out, (), {}),
+        daemon=True,
+    )
+    server.process.start()
+
+    loop = asyncio.get_running_loop()
+    server._init_fut = loop.create_future()
+    server._worker_dead = False
+    server.op_table = {}
+    server.stream_table = {}
+    server._queue_out_async = asyncio.Queue()
+    server._queue_out_stop = threading.Event()
+    server._queue_out_thread = threading.Thread(
+        target=server._queue_out_bridge,
+        args=(loop,),
+        daemon=True,
+    )
+    server._queue_out_thread.start()
+    server.recv_task = asyncio.create_task(server.recv_queue())
+
+    print(f"{elapsed()} Worker PID: {server.process.pid}")
+
+    # Wait for init
+    await asyncio.wait_for(server._init_fut, timeout=5.0)
+    print(f"{elapsed()} Worker ready (init_ok received)")
+
+    # Submit a request (worker will never respond)
+    print(f"{elapsed()} Submitting request...")
+    submit_task = asyncio.create_task(server.submit("health"))
+
+    # Give the request time to be queued
+    await asyncio.sleep(0.5)
+
+    # Kill the worker process (simulating OOM/segfault)
+    print(f"{elapsed()} Killing worker (simulating OOM crash)...")
+    os.kill(server.process.pid, signal.SIGKILL)
+
+    # Wait for the pending request to fail (with timeout)
+    detection_start = time.monotonic()
+    try:
+        result = await asyncio.wait_for(submit_task, timeout=5.0)
+        print(f"{elapsed()} ❌ UNEXPECTED: Request returned normally: {result}")
+        print("\nFAIL: Request should have raised RuntimeError")
+        sys.exit(1)
+    except RuntimeError as e:
+        detection_time = time.monotonic() - detection_start
+        print(f"{elapsed()} ✅ Request failed with: {type(e).__name__}('{e}')")
+    except asyncio.TimeoutError:
+        print(f"{elapsed()} ❌ TIMEOUT: Request hung for 5s — fix not working!")
+        print("\nFAIL: Worker death was not detected (hung forever)")
+        sys.exit(1)
+
+    # Try submitting after death — should fail immediately
+    print(f"{elapsed()} Attempting new submission after death...")
+    try:
+        await asyncio.wait_for(server.submit("health"), timeout=3.0)
+        print(f"{elapsed()} ❌ UNEXPECTED: New submission succeeded")
+        print("\nFAIL: submit() should reject after worker death")
+        sys.exit(1)
+    except RuntimeError as e:
+        print(f"{elapsed()} ✅ New submission rejected: {type(e).__name__}('{e}')")
+    except asyncio.TimeoutError:
+        print(f"{elapsed()} ❌ TIMEOUT: New submission hung — fix not working!")
+        print("\nFAIL: submit() should reject immediately after worker death")
+        sys.exit(1)
+
+    # Cleanup
+    server._queue_out_stop.set()
+    server._queue_out_thread.join(timeout=1.0)
+    server.recv_task.cancel()
+    try:
+        await server.recv_task
+    except asyncio.CancelledError:
+        pass
+
+    print(f"\nPASS: Worker death detected in {detection_time:.2f}s (would hang forever without fix)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/nanovllm_voxcpm/models/voxcpm/server.py
+++ b/nanovllm_voxcpm/models/voxcpm/server.py
@@ -23,6 +23,8 @@ from numpy.typing import NDArray
 
 Waveform = NDArray[np.float32]
 
+_WORKER_DEAD = object()  # Sentinel pushed to async queue when worker process dies
+
 
 class HealthResponse(TypedDict):
     status: Literal["ok"]
@@ -345,6 +347,7 @@ class AsyncVoxCPMServer:
         # but still fail fast if init throws (e.g. CUDA OOM).
         loop = asyncio.get_running_loop()
         self._init_fut: asyncio.Future[None] = loop.create_future()
+        self._worker_dead = False
 
         self.op_table: dict[str, asyncio.Future[Any]] = {}
         self.stream_table: dict[str, asyncio.Queue[Waveform | None]] = {}
@@ -364,8 +367,14 @@ class AsyncVoxCPMServer:
             try:
                 res = self.queue_out.get(timeout=0.1)
             except Empty:
+                # Check if the worker process died while we were waiting.
+                if self.process.exitcode is not None and not self._queue_out_stop.is_set():
+                    loop.call_soon_threadsafe(self._queue_out_async.put_nowait, _WORKER_DEAD)
+                    return
                 continue
             except (EOFError, OSError, ValueError):
+                if not self._queue_out_stop.is_set():
+                    loop.call_soon_threadsafe(self._queue_out_async.put_nowait, _WORKER_DEAD)
                 return
             try:
                 loop.call_soon_threadsafe(self._queue_out_async.put_nowait, res)
@@ -376,6 +385,16 @@ class AsyncVoxCPMServer:
         try:
             while True:
                 res = await self._queue_out_async.get()
+
+                if res is _WORKER_DEAD:
+                    self._worker_dead = True
+                    for op_id, fut in list(self.op_table.items()):
+                        if not fut.done():
+                            fut.set_exception(RuntimeError("VoxCPM worker process died unexpectedly"))
+                    self.op_table.clear()
+                    if not self._init_fut.done():
+                        self._init_fut.set_exception(RuntimeError("VoxCPM worker process died unexpectedly"))
+                    return
 
                 # Init handshake (sent once at process startup).
                 if res.get("type") == "init_ok":
@@ -407,6 +426,8 @@ class AsyncVoxCPMServer:
             return
 
     async def submit(self, cmd: str, *args: object, **kwargs: object) -> Any:
+        if self._worker_dead:
+            raise RuntimeError("VoxCPM worker process died unexpectedly — server must be restarted")
         op_id = str(uuid.uuid4())
 
         loop = asyncio.get_running_loop()

--- a/nanovllm_voxcpm/models/voxcpm2/server.py
+++ b/nanovllm_voxcpm/models/voxcpm2/server.py
@@ -23,6 +23,8 @@ from nanovllm_voxcpm.models.voxcpm2.runner import VoxCPM2Runner
 
 Waveform = NDArray[np.float32]
 
+_WORKER_DEAD = object()  # Sentinel pushed to async queue when worker process dies
+
 
 class HealthResponse(TypedDict):
     status: Literal["ok"]
@@ -300,6 +302,7 @@ class AsyncVoxCPM2Server:
         self.process.start()
         loop = asyncio.get_running_loop()
         self._init_fut: asyncio.Future[None] = loop.create_future()
+        self._worker_dead = False
         self.op_table: dict[str, asyncio.Future[Any]] = {}
         self.stream_table: dict[str, asyncio.Queue[Waveform | None]] = {}
         self._queue_out_async: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
@@ -318,8 +321,14 @@ class AsyncVoxCPM2Server:
             try:
                 res = self.queue_out.get(timeout=0.1)
             except Empty:
+                # Check if the worker process died while we were waiting.
+                if self.process.exitcode is not None and not self._queue_out_stop.is_set():
+                    loop.call_soon_threadsafe(self._queue_out_async.put_nowait, _WORKER_DEAD)
+                    return
                 continue
             except (EOFError, OSError, ValueError):
+                if not self._queue_out_stop.is_set():
+                    loop.call_soon_threadsafe(self._queue_out_async.put_nowait, _WORKER_DEAD)
                 return
             try:
                 loop.call_soon_threadsafe(self._queue_out_async.put_nowait, res)
@@ -330,6 +339,16 @@ class AsyncVoxCPM2Server:
         try:
             while True:
                 res = await self._queue_out_async.get()
+
+                if res is _WORKER_DEAD:
+                    self._worker_dead = True
+                    for op_id, fut in list(self.op_table.items()):
+                        if not fut.done():
+                            fut.set_exception(RuntimeError("VoxCPM worker process died unexpectedly"))
+                    self.op_table.clear()
+                    if not self._init_fut.done():
+                        self._init_fut.set_exception(RuntimeError("VoxCPM worker process died unexpectedly"))
+                    return
 
                 if res.get("type") == "init_ok":
                     if not self._init_fut.done():
@@ -356,6 +375,8 @@ class AsyncVoxCPM2Server:
             return
 
     async def submit(self, cmd: str, *args: object, **kwargs: object) -> Any:
+        if self._worker_dead:
+            raise RuntimeError("VoxCPM worker process died unexpectedly — server must be restarted")
         op_id = str(uuid.uuid4())
         loop = asyncio.get_running_loop()
         fut: asyncio.Future[Any] = loop.create_future()

--- a/tests/unit/test_worker_health.py
+++ b/tests/unit/test_worker_health.py
@@ -1,0 +1,213 @@
+"""Test worker death detection and fail-fast behavior (TDD).
+
+These tests exercise the public API of AsyncVoxCPMServer/AsyncVoxCPM2Server
+with real multiprocessing queues and the actual bridge thread + recv_queue.
+
+Test behaviour:
+- WITHOUT the worker-health fix: tests FAIL with asyncio.TimeoutError
+  (submit() hangs forever after worker death)
+- WITH the fix: tests PASS (submit() raises RuntimeError within ~0.2s)
+
+No test changes are needed between fail→pass — proper TDD.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import threading
+import time
+from typing import Any
+
+import pytest
+import torch.multiprocessing as mp
+
+
+# ---------------------------------------------------------------------------
+# Fake worker processes (used instead of the real GPU-dependent main_loop)
+# ---------------------------------------------------------------------------
+
+
+def _fake_worker_sleep(queue_in, queue_out, args, kwargs):
+    """Worker that acks init then sleeps forever (will be SIGKILL'd)."""
+    queue_out.put({"type": "init_ok"})
+    while True:
+        time.sleep(60)
+
+
+def _fake_worker_echo(queue_in, queue_out, args, kwargs):
+    """Worker that responds to all requests (for normal-path test)."""
+    queue_out.put({"type": "init_ok"})
+    while True:
+        try:
+            msg = queue_in.get(timeout=5)
+        except Exception:
+            return
+        if msg["type"] == "stop":
+            queue_out.put({"id": msg["id"], "type": "response", "data": None})
+            return
+        queue_out.put({"id": msg["id"], "type": "response", "data": {"status": "ok"}})
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _build_server():
+    """Factory fixture: builds an AsyncVoxCPM(2)Server with a fake worker."""
+    servers = []
+
+    async def _make(server_cls, worker_fn):
+        server = server_cls.__new__(server_cls)
+        ctx = mp.get_context("spawn")
+        server.queue_in = ctx.Queue()
+        server.queue_out = ctx.Queue()
+        server.process = ctx.Process(
+            target=worker_fn,
+            args=(server.queue_in, server.queue_out, (), {}),
+            daemon=True,
+        )
+        server.process.start()
+
+        loop = asyncio.get_running_loop()
+        server._init_fut = loop.create_future()
+        server._worker_dead = False
+        server.op_table: dict[str, asyncio.Future[Any]] = {}
+        server.stream_table: dict[str, asyncio.Queue] = {}
+        server._queue_out_async = asyncio.Queue()
+        server._queue_out_stop = threading.Event()
+        server._queue_out_thread = threading.Thread(
+            target=server._queue_out_bridge,
+            args=(loop,),
+            daemon=True,
+        )
+        server._queue_out_thread.start()
+        server.recv_task = asyncio.create_task(server.recv_queue())
+
+        await asyncio.wait_for(server._init_fut, timeout=5.0)
+        servers.append(server)
+        return server
+
+    yield _make
+
+    # Cleanup all servers created during the test
+    for server in servers:
+        server._queue_out_stop.set()
+        server._queue_out_thread.join(timeout=1.0)
+        server.recv_task.cancel()
+
+
+# ---------------------------------------------------------------------------
+# VoxCPM v1 tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::DeprecationWarning:torch")
+async def test_pending_request_fails_on_worker_death(_build_server, monkeypatch):
+    """After worker death, pending submit() raises RuntimeError (not hang)."""
+    import nanovllm_voxcpm.models.voxcpm.server as mod
+
+    monkeypatch.setattr(mod, "main_loop", _fake_worker_sleep)
+    server = await _build_server(mod.AsyncVoxCPMServer, _fake_worker_sleep)
+
+    # Submit a request (worker will never respond)
+    submit_task = asyncio.create_task(server.submit("health"))
+    await asyncio.sleep(0)  # let submit register in op_table
+
+    # Kill the worker (simulate OOM crash)
+    os.kill(server.process.pid, signal.SIGKILL)
+
+    # With fix: RuntimeError raised quickly. Without fix: hangs → TimeoutError
+    with pytest.raises(RuntimeError, match="worker process died"):
+        await asyncio.wait_for(submit_task, timeout=3.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::DeprecationWarning:torch")
+async def test_new_submit_rejects_after_death(_build_server, monkeypatch):
+    """After worker death, new submit() raises immediately (not hang)."""
+    import nanovllm_voxcpm.models.voxcpm.server as mod
+
+    monkeypatch.setattr(mod, "main_loop", _fake_worker_sleep)
+    server = await _build_server(mod.AsyncVoxCPMServer, _fake_worker_sleep)
+
+    # Kill the worker
+    os.kill(server.process.pid, signal.SIGKILL)
+    await asyncio.sleep(0.2)  # bridge polls every 0.1s
+
+    # New submission should fail immediately
+    with pytest.raises(RuntimeError, match="worker process died|server must be restarted"):
+        await asyncio.wait_for(server.submit("health"), timeout=3.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::DeprecationWarning:torch")
+async def test_normal_operation_unaffected(_build_server, monkeypatch):
+    """When worker is healthy, submit() resolves normally."""
+    import nanovllm_voxcpm.models.voxcpm.server as mod
+
+    monkeypatch.setattr(mod, "main_loop", _fake_worker_echo)
+    server = await _build_server(mod.AsyncVoxCPMServer, _fake_worker_echo)
+
+    result = await asyncio.wait_for(server.submit("health"), timeout=3.0)
+    assert result == {"status": "ok"}
+
+    await asyncio.wait_for(server.submit("stop"), timeout=3.0)
+
+
+# ---------------------------------------------------------------------------
+# VoxCPM2 tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::DeprecationWarning:torch")
+async def test_pending_request_fails_on_worker_death_v2(_build_server, monkeypatch):
+    """After worker death, pending submit() raises RuntimeError (voxcpm2)."""
+    import nanovllm_voxcpm.models.voxcpm2.server as mod
+
+    monkeypatch.setattr(mod, "main_loop", _fake_worker_sleep)
+    server = await _build_server(mod.AsyncVoxCPM2Server, _fake_worker_sleep)
+
+    submit_task = asyncio.create_task(server.submit("health"))
+    await asyncio.sleep(0)  # let submit register in op_table
+
+    os.kill(server.process.pid, signal.SIGKILL)
+
+    with pytest.raises(RuntimeError, match="worker process died"):
+        await asyncio.wait_for(submit_task, timeout=3.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::DeprecationWarning:torch")
+async def test_new_submit_rejects_after_death_v2(_build_server, monkeypatch):
+    """After worker death, new submit() raises immediately (voxcpm2)."""
+    import nanovllm_voxcpm.models.voxcpm2.server as mod
+
+    monkeypatch.setattr(mod, "main_loop", _fake_worker_sleep)
+    server = await _build_server(mod.AsyncVoxCPM2Server, _fake_worker_sleep)
+
+    os.kill(server.process.pid, signal.SIGKILL)
+    await asyncio.sleep(0.2)  # bridge polls every 0.1s
+
+    with pytest.raises(RuntimeError, match="worker process died|server must be restarted"):
+        await asyncio.wait_for(server.submit("health"), timeout=3.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::DeprecationWarning:torch")
+async def test_normal_operation_unaffected_v2(_build_server, monkeypatch):
+    """When worker is healthy, submit() resolves normally (voxcpm2)."""
+    import nanovllm_voxcpm.models.voxcpm2.server as mod
+
+    monkeypatch.setattr(mod, "main_loop", _fake_worker_echo)
+    server = await _build_server(mod.AsyncVoxCPM2Server, _fake_worker_echo)
+
+    result = await asyncio.wait_for(server.submit("health"), timeout=3.0)
+    assert result == {"status": "ok"}
+
+    await asyncio.wait_for(server.submit("stop"), timeout=3.0)


### PR DESCRIPTION
Fixes #84 

When the worker process dies (OOM, segfault, etc.), the queue bridge thread exits but recv_queue() awaits _queue_out_async.get() forever, causing all in-flight requests to hang indefinitely.

Fix: on each Empty timeout in the bridge thread, check process.exitcode. If the process has exited (and it's not a graceful stop), push a sentinel to the async queue. recv_queue() then errors out all pending futures and sets _worker_dead so submit() rejects new requests immediately.

Applied to both AsyncVoxCPMServer and AsyncVoxCPM2Server.

Includes:
- Automated tests (pytest) verifying error propagation and fail-fast
- Manual verification script (examples/verify_worker_health.py) that simulates worker death and shows detection timing (~0.1s vs forever)